### PR TITLE
refact: extract reusable task components

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,10 +1,9 @@
 import AddTaskButton from '@/components/AddTaskButton';
 import { LoadingSpinner } from '@/components/loading';
+import TaskItemsAccordion from '@/components/TaskItemsAccordion';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useTasks, useToggleTaskCompletion } from '@/hooks/useTasks';
-import FontAwesome from '@expo/vector-icons/FontAwesome';
-import { router } from 'expo-router';
 import React, { useState } from 'react';
 import { Alert, Pressable, Text, View } from 'react-native';
 
@@ -87,57 +86,14 @@ export default function HomeScreen() {
             </View>
           ) : (
             groupedTasks.map(({ category, items }) => (
-              <View key={category} className="mb-9">
-                <Pressable
-                  onPress={() => toggleAccordion(category)}
-                  className="flex flex-row items-center justify-between px-5 py-4 rounded-2xl mb-2 bg-[#2B42B6] shadow-md"
-                  style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}
-                >
-                  <View className="flex-row gap-2 items-center">
-                    <Text className="text-lg font-semibold capitalize text-[#E6FAFF] tracking-wide">{category}</Text>
-                    <Text className="bg-[#2E84FD] text-[#021A40] px-2 py-0.5 rounded-full min-w-[28px] text-center font-bold text-[15px]">
-                      {items.filter((item) => !item.completed).length}
-                    </Text>
-                  </View>
-                  <Text className="text-2xl text-[#E6FAFF]">
-                    {openCategories[category] ? <FontAwesome name="angle-down" size={26} color="#E6FAFF" /> : <FontAwesome name="angle-up" size={26} color="#E6FAFF" />}
-                  </Text>
-                </Pressable>
-
-                {openCategories[category] && items.length > 0 && (
-                  <View className="pl-5">
-                    {items.map((task) => (
-                      <View key={task.id} className="flex flex-row items-center mb-5">
-                        <Pressable
-                          testID="task-checkbox"
-                          onPress={() => handleToggle(task.id!, !task.completed)}
-                          className={`h-7 w-7 rounded-full border-2 mr-4 ${task.completed ? 'border-[#154FA6] bg-[#154FA6]' : 'border-[#708090] bg-[#021A40]'}`}
-                          style={{ alignItems: 'center', justifyContent: 'center', shadowColor: task.completed ? '#154FA6' : 'transparent', shadowOpacity: task.completed ? 0.12 : 0, shadowRadius: 4, shadowOffset: { width: 0, height: 1 } }}
-                        >
-                          {task.completed && (
-                            <View className="h-3 w-3 rounded-full bg-[#021A40]" />
-                          )}
-                        </Pressable>
-
-                        <View className="flex-1">
-                          <Text className={`font-bold ${task.completed ? 'text-[#708090]' : 'text-[#F1F5F9]'} text-[17px] mb-0.5 ${task.completed ? 'line-through' : ''} tracking-tight`} testID={`home-task-title-${task.id}`}>{task.title}</Text>
-                          {task.description ? (
-                            <Text className={`${task.completed ? 'text-[#708090]' : 'text-[#E6FAFF]'} text-[15px] tracking-tight`} testID={`home-task-description-${task.id}`}>{task.description}</Text>
-                          ) : null}
-                        </View>
-
-                        <Pressable
-                          testID="task-edit-icon"
-                          onPress={() => router.push(`/taskDetail/${task.id}`)}
-                          className="p-2 ml-2"
-                        >
-                          <FontAwesome name="edit" size={16} color="#708090" />
-                        </Pressable>
-                      </View>
-                    ))}
-                  </View>
-                )}
-              </View>
+              <TaskItemsAccordion
+                key={category}
+                category={category}
+                items={items}
+                isOpen={openCategories[category]}
+                onToggleAccordion={() => toggleAccordion(category)}
+                onToggleTask={handleToggle}
+              />
             ))
           )}
         </ScrollView>

--- a/app/(tabs)/todaysFocus.tsx
+++ b/app/(tabs)/todaysFocus.tsx
@@ -2,6 +2,7 @@ import { Task } from '@/api/tasks';
 import { AiTaskCard } from '@/components/AiTaskCard';
 import { PrimaryButton } from '@/components/buttons/';
 import { FocusModeScreen } from '@/components/FocusModeScreen';
+import { PRIORITY_OPTIONS } from '@/components/inputs';
 import { LoadingSpinner } from '@/components/loading';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
@@ -12,6 +13,7 @@ import { useCreateTask, useIncompleteTasks } from '@/hooks/useTasks';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useState } from 'react';
 import { Alert, Text, TouchableOpacity, View } from 'react-native';
+
 
 export default function TodaysFocusScreen() {
   const { profile } = useAuth();
@@ -153,6 +155,10 @@ export default function TodaysFocusScreen() {
     return selectedTasks.some(t => t.id === task.id);
   };
 
+  const getPriorityLabel = (priority: number): string => {
+    return PRIORITY_OPTIONS.find(p => p.value === priority)?.label || 'Priority';
+  };
+
   if (isFocusMode) {
     return (
       <FocusModeScreen
@@ -273,7 +279,7 @@ export default function TodaysFocusScreen() {
                           color={task.priority >= 3 ? Colors.accent.primary : Colors.text.muted}
                         />
                         <Text className="ml-1 text-xs text-slate-400" testID={`todays-focus-task-priority-${task.id}`}>
-                          Priority {task.priority}
+                          {getPriorityLabel(task.priority)}
                         </Text>
                       </View>
                     )}

--- a/app/addTask/index.tsx
+++ b/app/addTask/index.tsx
@@ -1,5 +1,6 @@
 import { CreateTaskParams } from '@/api/tasks';
 import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
+import { PriorityInput } from '@/components/inputs';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useCreateTask } from '@/hooks/useTasks';
@@ -86,31 +87,12 @@ export default function AddTaskScreen() {
               testID="add-task-task-description-input"
             />
 
-            <View className="mb-5">
-              <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Priority:</Text>
-              <View className="flex-row gap-2">
-                {([1, 2, 3, 4, 5] as const).map((priority) => (
-                  <Pressable
-                    key={`priority-${priority}`}
-                    onPress={() => handlePriorityChange(priority)}
-                    className={`flex-1 py-2 px-3 rounded-lg border ${taskDetails.priority === priority
-                      ? 'border-cyan-400 bg-cyan-400'
-                      : 'border-[#708090] bg-[#13203a]'
-                      }`}
-                    disabled={createTaskMutation.isPending}
-                  >
-                    <Text
-                      className={`text-center font-medium capitalize ${taskDetails.priority === priority
-                        ? 'text-[#021A40]'
-                        : 'text-[#E6FAFF]'
-                        }`}
-                    >
-                      {priority}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
-            </View>
+            <PriorityInput
+              value={taskDetails.priority}
+              onChange={handlePriorityChange}
+              disabled={createTaskMutation.isPending}
+              showLabel
+            />
 
             <View className="mb-5">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Action Category:</Text>

--- a/app/taskDetail/[id].tsx
+++ b/app/taskDetail/[id].tsx
@@ -1,4 +1,5 @@
 import { UpdateTaskParams } from '@/api/tasks';
+import { PRIORITY_OPTIONS, PriorityInput } from '@/components/inputs';
 import { LoadingSpinner } from '@/components/loading';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
@@ -263,50 +264,16 @@ export default function TaskDetailScreen() {
             <View className="mb-6">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Priority</Text>
               {isEditing ? (
-                <View className="flex-row gap-2">
-                  {[1, 2, 3, 4, 5].map((priority) => (
-                    <Pressable
-                      key={`priority-${priority}`}
-                      onPress={() => handlePriorityChange(priority)}
-                      className={`flex-1 py-3 px-4 rounded-lg border ${taskDetails.priority === priority
-                        ? 'border-[#33CFFF] bg-cyan-400'
-                        : 'border-[#708090] bg-[#13203a]'
-                        }`}
-                      disabled={updateTaskMutation.isPending}
-                    >
-                      <Text
-                        className={`text-center font-medium capitalize ${taskDetails.priority === priority
-                          ? 'text-[#021A40]'
-                          : 'text-[#E6FAFF]'
-                          }`}
-                      >
-                        {priority}
-                      </Text>
-                    </Pressable>
-                  ))}
-                </View>
+                <PriorityInput
+                  value={taskDetails.priority}
+                  onChange={handlePriorityChange}
+                  disabled={updateTaskMutation.isPending}
+                />
               ) : (
-                <View className="flex-row gap-2 px-4 py-3">
-                  {[1, 2, 3, 4, 5].map((priority) => (
-                    <Pressable
-                      key={`priority-${priority}`}
-                      onPress={() => handlePriorityChange(priority)}
-                      className={`flex-1 py-3 px-4 rounded-lg border ${taskDetails.priority === priority
-                        ? 'border-[#33CFFF] bg-cyan-400'
-                        : 'border-[#708090] bg-[#13203a]'
-                        }`}
-                      disabled={updateTaskMutation.isPending}
-                    >
-                      <Text
-                        className={`text-center font-medium capitalize ${taskDetails.priority === priority
-                          ? 'text-[#021A40]'
-                          : 'text-[#E6FAFF]'
-                          }`}
-                      >
-                        {priority}
-                      </Text>
-                    </Pressable>
-                  ))}
+                <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
+                  <Text className="text-[#F1F5F9] text-base capitalize">
+                    {PRIORITY_OPTIONS.find(p => p.value === task.priority)?.label || task.priority}
+                  </Text>
                 </View>
               )}
             </View>

--- a/components/FocusModeScreen.tsx
+++ b/components/FocusModeScreen.tsx
@@ -1,4 +1,5 @@
 import { Task } from '@/api/tasks';
+import { PRIORITY_OPTIONS } from '@/components/inputs';
 import LinearGradient from '@/components/ui/LinearGradient';
 import { Colors } from '@/constants/Colors';
 import { useUpdateTask } from '@/hooks/useTasks';
@@ -140,6 +141,10 @@ export function FocusModeScreen({ selectedTasks, onComplete, onExit }: FocusMode
     onExit();
   };
 
+  const getPriorityLabel = (priority: number): string => {
+    return PRIORITY_OPTIONS.find(p => p.value === priority)?.label || 'Priority';
+  };
+
   if (!currentTask || allTasksCompleted) {
     return (
       <LinearGradient>
@@ -208,7 +213,7 @@ export function FocusModeScreen({ selectedTasks, onComplete, onExit }: FocusMode
                   color={currentTask.priority >= 3 ? Colors.accent.primary : Colors.text.muted}
                 />
                 <Text className="text-sm text-slate-200 ml-1.5" testID="focus-mode-task-priority">
-                  Priority {currentTask.priority}
+                  {getPriorityLabel(currentTask.priority)}
                 </Text>
               </View>
             )}

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -1,0 +1,57 @@
+import { Task } from '@/api/tasks';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import { router } from 'expo-router';
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+interface TaskItemProps {
+  task: Task;
+  onToggle: (taskId: number, completed: boolean) => void;
+}
+
+export default function TaskItem({ task, onToggle }: TaskItemProps) {
+  const getCheckboxClassName = () => {
+    const baseClasses = 'h-7 w-7 rounded-full border-2 mr-4';
+    if (task.completed) {
+      return `${baseClasses} border-[#154FA6] bg-[#154FA6]`;
+    }
+    if (task.priority === 1) {
+      return `${baseClasses} border-[#EF4444] bg-[#021A40]`;
+    }
+    if (task.priority === 2) {
+      return `${baseClasses} border-[#EAB308] bg-[#021A40]`;
+    }
+    return `${baseClasses} border-[#708090] bg-[#021A40]`;
+  };
+
+  return (
+    <View className="flex flex-row items-center mb-5">
+      <Pressable
+        testID="task-checkbox"
+        onPress={() => onToggle(task.id!, !task.completed)}
+        className={getCheckboxClassName()}
+        style={{ alignItems: 'center', justifyContent: 'center', shadowColor: task.completed ? '#154FA6' : 'transparent', shadowOpacity: task.completed ? 0.12 : 0, shadowRadius: 4, shadowOffset: { width: 0, height: 1 } }}
+      >
+        {task.completed && (
+          <View className="h-3 w-3 rounded-full bg-[#021A40]" />
+        )}
+      </Pressable>
+
+      <View className="flex-1">
+        <Text className={`font-bold ${task.completed ? 'text-[#708090]' : 'text-[#F1F5F9]'} text-[17px] mb-0.5 ${task.completed ? 'line-through' : ''} tracking-tight`} testID={`home-task-title-${task.id}`}>{task.title}</Text>
+        {task.description ? (
+          <Text className={`${task.completed ? 'text-[#708090]' : 'text-[#E6FAFF]'} text-[15px] tracking-tight`} testID={`home-task-description-${task.id}`}>{task.description}</Text>
+        ) : null}
+      </View>
+
+      <Pressable
+        testID="task-edit-icon"
+        onPress={() => router.push(`/taskDetail/${task.id}`)}
+        className="p-2 ml-2"
+      >
+        <FontAwesome name="edit" size={16} color="#708090" />
+      </Pressable>
+    </View>
+  );
+}
+

--- a/components/TaskItemsAccordion.tsx
+++ b/components/TaskItemsAccordion.tsx
@@ -1,0 +1,61 @@
+import { Task } from '@/api/tasks';
+import FontAwesome from '@expo/vector-icons/FontAwesome';
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import TaskItem from './TaskItem';
+
+interface TaskItemsAccordionProps {
+  category: string;
+  items: Task[];
+  isOpen: boolean;
+  onToggleAccordion: () => void;
+  onToggleTask: (taskId: number, completed: boolean) => void;
+}
+
+export default function TaskItemsAccordion({
+  category,
+  items,
+  isOpen,
+  onToggleAccordion,
+  onToggleTask,
+}: TaskItemsAccordionProps) {
+
+  // TODO:
+  // order the items in this order:
+  // 1. priority 1 and due today
+  // 2. priority 2 and due today
+  // 3. priority 3 and due today
+  // 4. priority 1 and not due date
+  // 5. priotrity 2
+  // 6. priority 3
+
+
+  return (
+    <View className="mb-9">
+      <Pressable
+        onPress={onToggleAccordion}
+        className="flex flex-row items-center justify-between px-5 py-4 rounded-2xl mb-2 bg-[#2B42B6] shadow-md"
+        style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}
+      >
+        <View className="flex-row gap-2 items-center">
+          <Text className="text-lg font-semibold capitalize text-[#E6FAFF] tracking-wide">{category}</Text>
+          <Text className="bg-[#2E84FD] text-[#021A40] px-2 py-0.5 rounded-full min-w-[28px] text-center font-bold text-[15px]">
+            {items.filter((item) => !item.completed).length}
+          </Text>
+        </View>
+        <Text className="text-2xl text-[#E6FAFF]">
+          {isOpen ? <FontAwesome name="angle-down" size={26} color="#E6FAFF" /> : <FontAwesome name="angle-up" size={26} color="#E6FAFF" />}
+        </Text>
+      </Pressable>
+
+      {isOpen && items.length > 0 && (
+        <View className="pl-5">
+          {items.map((task) => (
+            <TaskItem key={task.id} task={task} onToggle={onToggleTask} />
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+

--- a/components/inputs/PriorityInput.tsx
+++ b/components/inputs/PriorityInput.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+export type PriorityOption = {
+  label: string;
+  value: number;
+};
+
+export const PRIORITY_OPTIONS: PriorityOption[] = [
+  { label: 'High', value: 1 },
+  { label: 'Med', value: 2 },
+  { label: 'Low', value: 3 },
+];
+
+type PriorityInputProps = {
+  value: number;
+  onChange: (priority: number) => void;
+  options?: PriorityOption[];
+  disabled?: boolean;
+  showLabel?: boolean;
+  label?: string;
+  testID?: string;
+};
+
+export function PriorityInput({
+  value,
+  onChange,
+  options = PRIORITY_OPTIONS,
+  disabled = false,
+  showLabel = false,
+  label = 'Priority:',
+  testID,
+}: PriorityInputProps) {
+  const content = (
+    <View className="flex-row gap-2">
+      {options.map((option) => (
+        <Pressable
+          key={`priority-${option.value}`}
+          onPress={() => onChange(option.value)}
+          className={`flex-1 py-3 px-4 rounded-lg border ${value === option.value
+            ? 'border-cyan-400 bg-cyan-400'
+            : 'border-[#708090] bg-[#13203a]'
+            }`}
+          disabled={disabled}
+          testID={testID ? `${testID}-option-${option.value}` : undefined}
+        >
+          <Text
+            className={`text-center font-medium capitalize ${value === option.value
+              ? 'text-[#021A40]'
+              : 'text-[#E6FAFF]'
+              }`}
+          >
+            {option.label}
+          </Text>
+        </Pressable>
+      ))}
+    </View>
+  );
+
+  if (showLabel) {
+    return (
+      <View className="mb-5" testID={testID}>
+        <Text className="text-[#E6FAFF] text-base mb-3 font-medium">{label}</Text>
+        {content}
+      </View>
+    );
+  }
+
+  return content;
+}
+

--- a/components/inputs/index.ts
+++ b/components/inputs/index.ts
@@ -1,0 +1,3 @@
+export { PRIORITY_OPTIONS, PriorityInput } from './PriorityInput';
+export type { PriorityOption } from './PriorityInput';
+


### PR DESCRIPTION
## Summary
Pulls four duplicated copies of the priority selector and the home screen's
inline category accordion out into shared components so that the home,
add-task, task-detail, today's-focus, and focus-mode screens render task UI
through one set of building blocks.

Adds a `components/inputs/` barrel anchored by `PriorityInput`, plus
`components/TaskItem` and `components/TaskItemsAccordion` for the home
screen's grouped task list. As part of the priority extraction, priority is
standardized to three labeled options (High / Med / Low) instead of the
previous numeric 1–5 selector, and read-only views (today's focus, focus
mode, task detail view) now render the same labels.

### Why
The priority pickers in `addTask` and `taskDetail`, plus the accordion in
the home screen, were drifting copies of the same markup. Subsequent tickets
in this area need a single place to evolve task styling and ordering, so
this refactor unblocks that.

## Changes
- `components/inputs/PriorityInput.tsx`
  - New shared selector; exposes `PRIORITY_OPTIONS` (High / Med / Low) and an optional inline label.
- `components/inputs/index.ts`
  - Barrel re-exporting `PriorityInput`, `PRIORITY_OPTIONS`, and `PriorityOption`.
- `app/addTask/index.tsx`
  - Replaces inline priority `Pressable` row with `<PriorityInput showLabel />`.
- `app/taskDetail/[id].tsx`
  - Edit mode uses `PriorityInput`; read-only mode renders the matching `PRIORITY_OPTIONS` label.
- `app/(tabs)/todaysFocus.tsx`
  - Replaces "Priority N" with the High/Med/Low label via a `getPriorityLabel` helper.
- `components/FocusModeScreen.tsx`
  - Same priority-label swap as today's focus.
- `components/TaskItem.tsx`
  - New row component; checkbox border tints by priority (P1 red, P2 yellow, default slate).
- `components/TaskItemsAccordion.tsx`
  - New category accordion that wraps `TaskItem` and exposes open/toggle handlers.
- `app/(tabs)/index.tsx`
  - Renders grouped tasks through `TaskItemsAccordion` instead of inline JSX.

## Test Plan
- [ ] `npx expo start` — manually exercise add-task, task-detail (view + edit), home accordion, today's focus list, and focus mode to confirm priority labels and task interactions still work.
- [ ] Verify P1/P2 checkbox borders render with the new tint on the home screen.

## Additional Notes
- Priority data model is unchanged (still numeric); only the rendered labels and selector options changed.
- `TaskItemsAccordion.tsx` carries a TODO comment outlining a future ordering rule (priority + due date) — intentionally out of scope for this PR.