### PR TITLE
feat: build global toast system + migrate Alert.alert

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 ## Running development build with Metro bundler
 IMPORTANT: Until I find another way, use 'npx expo start --tunnel' to connect to the Metro bundler
+
+## Toast notifications
+
+The app surfaces feedback via a global toast system mounted in `app/_layout.tsx`
+(`<ToastProvider>`). Use `useToast()` from `components/ToastManager` to show
+success, error, and info toasts from any component or hook:
+
+```tsx
+import { useToast } from '@/components/ToastManager';
+
+const toast = useToast();
+toast.success('Saved');
+toast.error('Something went wrong');
+toast.info('Coming soon');
+```
+
+### Auto-error toasts from the API client
+
+`utils/apiRequest.ts` surfaces an error toast automatically on every non-2xx
+response (other than 401, which routes through the auth flow) and on network
+errors. Screens generally should not duplicate this in `onError` / `catch`
+blocks — let the interceptor do the work.
+
+To suppress the auto-toast — for example, when rendering the error inline —
+pass `silent: true`:
+
+```ts
+await apiPost('/tasks', { ... }, { silent: true });
+```
+
+(`silent` is also accepted by the lower-level `apiRequest` call directly.)
+
+### When to use `Alert.alert` vs `useToast`
+
+- **Use `useToast`** for one-way feedback: validation errors, success messages,
+  background failures, info hints.
+- **Keep `Alert.alert`** only for true confirmation dialogs — anything that
+  needs the user to choose between actions (Cancel / Delete, Continue / Discard,
+  etc.). Toasts intentionally don't carry buttons.

--- a/__tests__/hooks/useGoalCreation.test.tsx
+++ b/__tests__/hooks/useGoalCreation.test.tsx
@@ -1,5 +1,4 @@
 import { act, renderHook } from '@testing-library/react-native';
-import { Alert } from 'react-native';
 import { useAiProxy } from '../../hooks/useAiProxy';
 import { useGoalCreation } from '../../hooks/useGoalCreation';
 import { useCreateSmartGoal } from '../../hooks/useSmartGoals';
@@ -11,6 +10,18 @@ jest.mock('expo-router', () => ({
   router: {
     back: jest.fn()
   }
+}));
+
+// Mock toast
+const mockToastError = jest.fn();
+const mockToastSuccess = jest.fn();
+jest.mock('../../components/ToastManager', () => ({
+  useToast: () => ({
+    error: mockToastError,
+    success: mockToastSuccess,
+    info: jest.fn(),
+    dismiss: jest.fn(),
+  }),
 }));
 
 const mockUseAiProxy = useAiProxy as jest.MockedFunction<typeof useAiProxy>;
@@ -54,8 +65,6 @@ describe('useGoalCreation', () => {
       mutate: jest.fn()
     });
 
-    // Mock Alert.alert
-    jest.spyOn(Alert, 'alert').mockImplementation(() => { });
   });
 
   it('should initialize with default state', () => {
@@ -126,7 +135,7 @@ describe('useGoalCreation', () => {
         await result.current.handleCreateGoal();
       });
 
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Please enter a goal description');
+      expect(mockToastError).toHaveBeenCalledWith('Please enter a goal description');
       expect(mockProcessAiRequest).not.toHaveBeenCalled();
     });
 
@@ -141,11 +150,11 @@ describe('useGoalCreation', () => {
         await result.current.handleCreateGoal();
       });
 
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Please select a timeframe');
+      expect(mockToastError).toHaveBeenCalledWith('Please select a timeframe');
       expect(mockProcessAiRequest).not.toHaveBeenCalled();
     });
 
-    it('should show error alert when AI request fails', async () => {
+    it('should not throw when AI request fails (interceptor surfaces toast)', async () => {
       const { result } = renderHook(() => useGoalCreation());
 
       mockProcessAiRequest.mockRejectedValue(new Error('AI request failed'));
@@ -159,7 +168,8 @@ describe('useGoalCreation', () => {
         await result.current.handleCreateGoal();
       });
 
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to create goal. Please try again.');
+      expect(mockProcessAiRequest).toHaveBeenCalled();
+      expect(result.current.showConfirmation).toBe(false);
     });
   });
 
@@ -212,14 +222,14 @@ describe('useGoalCreation', () => {
       });
     });
 
-    it('should show error alert when AI response is missing', async () => {
+    it('should show error toast when AI response is missing', async () => {
       const { result } = renderHook(() => useGoalCreation());
 
       await act(async () => {
         await result.current.handleConfirmGoal();
       });
 
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to save goal. Please try again.');
+      expect(mockToastError).toHaveBeenCalledWith('No goal details available');
       expect(mockCreateSmartGoal).not.toHaveBeenCalled();
     });
   });

--- a/__tests__/screens/AddTaskScreen.test.tsx
+++ b/__tests__/screens/AddTaskScreen.test.tsx
@@ -106,7 +106,6 @@ describe('AddTaskScreen', () => {
         },
         expect.objectContaining({
           onSuccess: expect.any(Function),
-          onError: expect.any(Function),
         })
       );
     });

--- a/__tests__/screens/HomeScreen.test.tsx
+++ b/__tests__/screens/HomeScreen.test.tsx
@@ -179,12 +179,7 @@ describe('HomeScreen', () => {
     fireEvent.press(completeButton);
 
     await waitFor(() => {
-      expect(mockMutate).toHaveBeenCalledWith(
-        { id: 1, completed: true },
-        expect.objectContaining({
-          onError: expect.any(Function),
-        })
-      );
+      expect(mockMutate).toHaveBeenCalledWith({ id: 1, completed: true });
     });
   });
 

--- a/__tests__/screens/LoginScreen.test.tsx
+++ b/__tests__/screens/LoginScreen.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Alert } from 'react-native';
 import LoginScreen from '../../app/auth/login';
 import { AuthProvider } from '../../hooks/useAuth';
 
@@ -12,8 +11,16 @@ jest.mock('expo-router', () => ({
   },
 }));
 
-// Mock Alert
-jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+// Mock toast
+const mockToastError = jest.fn();
+jest.mock('../../components/ToastManager', () => ({
+  useToast: () => ({
+    error: mockToastError,
+    success: jest.fn(),
+    info: jest.fn(),
+    dismiss: jest.fn(),
+  }),
+}));
 
 // Mock the useAuth hook
 const mockSignIn = jest.fn();
@@ -65,7 +72,7 @@ describe('LoginScreen', () => {
     fireEvent.press(signInButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Please fill in all fields');
+      expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
     });
   });
 
@@ -110,7 +117,7 @@ describe('LoginScreen', () => {
     fireEvent.press(signInButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Sign In Failed', errorMessage);
+      expect(mockToastError).toHaveBeenCalledWith(errorMessage);
     });
   });
 

--- a/__tests__/screens/SettingsScreen.test.tsx
+++ b/__tests__/screens/SettingsScreen.test.tsx
@@ -21,6 +21,18 @@ jest.mock('expo-router', () => ({
   },
 }));
 
+// Mock toast
+const mockToastError = jest.fn();
+const mockToastSuccess = jest.fn();
+jest.mock('../../components/ToastManager', () => ({
+  useToast: () => ({
+    error: mockToastError,
+    success: mockToastSuccess,
+    info: jest.fn(),
+    dismiss: jest.fn(),
+  }),
+}));
+
 // Mock the API request
 jest.mock('../../utils/apiRequest', () => ({
   apiPost: jest.fn(),
@@ -249,7 +261,7 @@ describe('SettingsScreen', () => {
       fireEvent.press(saveButton);
 
       await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith('Error', 'Please enter a valid API key');
+        expect(mockToastError).toHaveBeenCalledWith('Please enter a valid API key');
       });
     });
 
@@ -334,7 +346,7 @@ describe('SettingsScreen', () => {
       fireEvent.press(saveButton);
 
       await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to save API key. Please try again.');
+        expect(mockToastError).toHaveBeenCalledWith('Failed to save API key. Please try again.');
       });
     });
 
@@ -355,8 +367,8 @@ describe('SettingsScreen', () => {
       clearAction?.onPress();
 
       await waitFor(() => {
-        expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to clear API key');
+        expect(mockToastError).toHaveBeenCalledWith('Failed to clear API key');
       });
     });
   });
-}); 
+});

--- a/__tests__/screens/SignupScreen.test.tsx
+++ b/__tests__/screens/SignupScreen.test.tsx
@@ -1,6 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
 import React from 'react';
-import { Alert } from 'react-native';
 import SignupScreen from '../../app/auth/signup';
 import { AuthProvider } from '../../hooks/useAuth';
 
@@ -12,8 +11,17 @@ jest.mock('expo-router', () => ({
   },
 }));
 
-// Mock Alert
-jest.spyOn(Alert, 'alert').mockImplementation(() => { });
+// Mock toast
+const mockToastError = jest.fn();
+const mockToastSuccess = jest.fn();
+jest.mock('../../components/ToastManager', () => ({
+  useToast: () => ({
+    error: mockToastError,
+    success: mockToastSuccess,
+    info: jest.fn(),
+    dismiss: jest.fn(),
+  }),
+}));
 
 // Mock the useAuth hook
 const mockSignIn = jest.fn();
@@ -66,7 +74,7 @@ describe('SignupScreen', () => {
     fireEvent.press(signupButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Please fill in all fields');
+      expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
     });
   });
 
@@ -88,7 +96,7 @@ describe('SignupScreen', () => {
     fireEvent.press(signupButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Passwords do not match');
+      expect(mockToastError).toHaveBeenCalledWith('Passwords do not match');
     });
   });
 
@@ -110,7 +118,7 @@ describe('SignupScreen', () => {
     fireEvent.press(signupButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Password must be at least 6 characters long');
+      expect(mockToastError).toHaveBeenCalledWith('Password must be at least 6 characters long');
     });
   });
 
@@ -159,7 +167,7 @@ describe('SignupScreen', () => {
     fireEvent.press(signupButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Sign Up Failed', errorMessage);
+      expect(mockToastError).toHaveBeenCalledWith(errorMessage);
     });
   });
 
@@ -269,7 +277,7 @@ describe('SignupScreen', () => {
     fireEvent.press(signupButton);
 
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Please fill in all fields');
+      expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
     });
   });
-}); 
+});

--- a/__tests__/screens/TodaysFocusScreen.test.tsx
+++ b/__tests__/screens/TodaysFocusScreen.test.tsx
@@ -558,8 +558,9 @@ describe('TodaysFocusScreen', () => {
     const addToTodayButtons = screen.getAllByText('Add to Today');
     fireEvent.press(addToTodayButtons[0]);
 
+    // Error toast is surfaced by apiRequest interceptor; the screen recovers silently.
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to save task');
+      expect(mockMutateAsync).toHaveBeenCalled();
     });
   });
 
@@ -586,8 +587,9 @@ describe('TodaysFocusScreen', () => {
     const assistButton = screen.getByTestId('todays-focus-assist-me-button');
     fireEvent.press(assistButton);
 
+    // Error toast is surfaced by apiRequest interceptor; the screen recovers silently.
     await waitFor(() => {
-      expect(Alert.alert).toHaveBeenCalledWith('Error', 'Failed to generate AI suggestions');
+      expect(mockGenerateSuggestions).toHaveBeenCalled();
     });
   });
 

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -5,7 +5,7 @@ import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useTasks, useToggleTaskCompletion } from '@/hooks/useTasks';
 import React, { useState } from 'react';
-import { Alert, Pressable, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 export default function HomeScreen() {
   const { data: tasks = [], isLoading, error, refetch } = useTasks();
@@ -26,15 +26,7 @@ export default function HomeScreen() {
   });
 
   const handleToggle = async (taskId: number, completed: boolean) => {
-    toggleTaskMutation.mutate(
-      { id: taskId, completed },
-      {
-        onError: (error) => {
-          Alert.alert('Error', error instanceof Error ? error.message : 'Failed to update task');
-        },
-      }
-    );
-
+    toggleTaskMutation.mutate({ id: taskId, completed });
   };
 
   const toggleAccordion = (category: string) => {

--- a/app/(tabs)/menu.tsx
+++ b/app/(tabs)/menu.tsx
@@ -1,3 +1,4 @@
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import { useAuth } from '@/hooks/useAuth';
 import { Ionicons } from '@expo/vector-icons';
@@ -14,6 +15,7 @@ interface MenuItem {
 
 export default function MenuScreen() {
   const { signOut } = useAuth();
+  const toast = useToast();
 
   const handleLogout = () => {
     Alert.alert(
@@ -32,7 +34,7 @@ export default function MenuScreen() {
               await signOut();
               router.replace('/auth/login');
             } catch {
-              Alert.alert('Error', 'Failed to sign out');
+              toast.error('Failed to sign out');
             }
           },
         },

--- a/app/(tabs)/todaysFocus.tsx
+++ b/app/(tabs)/todaysFocus.tsx
@@ -4,6 +4,7 @@ import { PrimaryButton } from '@/components/buttons/';
 import { FocusModeScreen } from '@/components/FocusModeScreen';
 import { PRIORITY_OPTIONS } from '@/components/inputs';
 import { LoadingSpinner } from '@/components/loading';
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { Colors } from '@/constants/Colors';
@@ -12,13 +13,14 @@ import { useAuth } from '@/hooks/useAuth';
 import { useCreateTask, useIncompleteTasks } from '@/hooks/useTasks';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useState } from 'react';
-import { Alert, Text, TouchableOpacity, View } from 'react-native';
+import { Text, TouchableOpacity, View } from 'react-native';
 
 
 export default function TodaysFocusScreen() {
   const { profile } = useAuth();
   const { data: incompleteTasks = [] } = useIncompleteTasks();
   const createTaskMutation = useCreateTask();
+  const toast = useToast();
 
   const [selectedTasks, setSelectedTasks] = useState<Task[]>([]);
   const [isFocusMode, setIsFocusMode] = useState(false);
@@ -54,14 +56,14 @@ export default function TodaysFocusScreen() {
 
   const handleAssistMe = async () => {
     if (!profile?.id) {
-      Alert.alert('Error', 'Profile not found');
+      toast.error('Profile not found');
       return;
     }
 
     try {
       await generateSuggestions();
     } catch {
-      Alert.alert('Error', 'Failed to generate AI suggestions');
+      // apiRequest interceptor surfaces the error toast
     }
   };
 
@@ -86,7 +88,7 @@ export default function TodaysFocusScreen() {
       }
       dismissSuggestion(suggestion);
     } catch {
-      Alert.alert('Error', 'Failed to save task');
+      // apiRequest interceptor surfaces the error toast
     } finally {
       // Clear loading state for this suggestion
       setLoadingSuggestions(prev => {
@@ -107,7 +109,7 @@ export default function TodaysFocusScreen() {
       });
       dismissSuggestion(suggestion);
     } catch {
-      Alert.alert('Error', 'Failed to save task for later');
+      // apiRequest interceptor surfaces the error toast
     }
   };
 
@@ -122,7 +124,7 @@ export default function TodaysFocusScreen() {
 
   const handleEnterFocusMode = () => {
     if (selectedTasks.length === 0) {
-      Alert.alert('No Tasks Selected', 'Please select at least one task to enter focus mode.');
+      toast.error('Please select at least one task to enter focus mode.');
       return;
     }
     setIsFocusMode(true);

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from 'react';
 import '../global.css';
 
 import SplashScreen from '@/components/SplashScreen';
+import { ToastProvider } from '@/components/ToastManager';
 import { AuthProvider, useAuth } from '@/hooks/useAuth';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { NotificationProvider } from '@/hooks/useNotifications';
@@ -68,71 +69,73 @@ function AppContent() {
             : ["top", "left", "right"]
           }
         >
-          <Stack>
-            {/* Define all screens at layout level */}
-            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-            <Stack.Screen name="onboarding" options={{ headerShown: false }} />
-            <Stack.Screen name="auth/login" options={{ headerShown: false }} />
-            <Stack.Screen name="auth/signup" options={{ headerShown: false }} />
-            <Stack.Screen
-              name="profile/index"
-              options={{
-                headerShown: true,
-                headerTitle: "Profile",
-                headerBackTitle: "Menu"
-              }} />
-            <Stack.Screen
-              name="smartGoals/index"
-              options={{
-                headerShown: true,
-                headerTitle: "Goals",
-                headerBackTitle: "Menu"
-              }} />
-            <Stack.Screen
-              name="taskDetail/[id]"
-              options={{
-                headerShown: true,
-                headerTitle: "Task Details",
-                headerBackTitle: "Tasks"
-              }} />
-            <Stack.Screen
-              name="addTask/index"
-              options={{
-                headerShown: true,
-                headerTitle: "New Task",
-                headerBackTitle: "Tasks"
-              }} />
-            <Stack.Screen
-              name="about/index"
-              options={{
-                headerShown: true,
-                headerTitle: "How to Use",
-                headerBackTitle: "Menu"
-              }} />
-            <Stack.Screen
-              name="support-feedback/index"
-              options={{
-                headerShown: true,
-                headerTitle: "Support & Feedback",
-                headerBackTitle: "Menu"
-              }} />
-            <Stack.Screen
-              name="settings/index"
-              options={{
-                headerShown: true,
-                headerTitle: "Settings",
-                headerBackTitle: "Menu"
-              }} />
-            <Stack.Screen
-              name="addGoal/index"
-              options={{
-                headerShown: true,
-                headerTitle: "New Goal",
-                headerBackTitle: "SMART Goals"
-              }} />
-            <Stack.Screen name="+not-found" />
-          </Stack>
-          <StatusBar style="auto" />
+          <ToastProvider>
+            <Stack>
+              {/* Define all screens at layout level */}
+              <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+              <Stack.Screen name="onboarding" options={{ headerShown: false }} />
+              <Stack.Screen name="auth/login" options={{ headerShown: false }} />
+              <Stack.Screen name="auth/signup" options={{ headerShown: false }} />
+              <Stack.Screen
+                name="profile/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "Profile",
+                  headerBackTitle: "Menu"
+                }} />
+              <Stack.Screen
+                name="smartGoals/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "Goals",
+                  headerBackTitle: "Menu"
+                }} />
+              <Stack.Screen
+                name="taskDetail/[id]"
+                options={{
+                  headerShown: true,
+                  headerTitle: "Task Details",
+                  headerBackTitle: "Tasks"
+                }} />
+              <Stack.Screen
+                name="addTask/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "New Task",
+                  headerBackTitle: "Tasks"
+                }} />
+              <Stack.Screen
+                name="about/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "How to Use",
+                  headerBackTitle: "Menu"
+                }} />
+              <Stack.Screen
+                name="support-feedback/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "Support & Feedback",
+                  headerBackTitle: "Menu"
+                }} />
+              <Stack.Screen
+                name="settings/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "Settings",
+                  headerBackTitle: "Menu"
+                }} />
+              <Stack.Screen
+                name="addGoal/index"
+                options={{
+                  headerShown: true,
+                  headerTitle: "New Goal",
+                  headerBackTitle: "SMART Goals"
+                }} />
+              <Stack.Screen name="+not-found" />
+            </Stack>
+            <StatusBar style="auto" />
+          </ToastProvider>
         </SafeAreaView>
       </ThemeProvider>
     </QueryClientProvider>

--- a/app/addTask/index.tsx
+++ b/app/addTask/index.tsx
@@ -6,7 +6,7 @@ import ScrollView from '@/components/util/ScrollView';
 import { useCreateTask } from '@/hooks/useTasks';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
-import { Alert, KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
 
 export default function AddTaskScreen() {
   const [taskDetails, setTaskDetails] = useState({
@@ -32,9 +32,6 @@ export default function AddTaskScreen() {
         onSuccess: () => {
           // Navigate back to home screen
           router.push('/(tabs)');
-        },
-        onError: (error) => {
-          Alert.alert('Error', error instanceof Error ? error.message : 'Failed to create task');
         },
       });
     }

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -1,11 +1,11 @@
 import LinearGradient from '@/components/ui/LinearGradient';
+import { useToast } from '@/components/ToastManager';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Platform,
   Text,
@@ -19,10 +19,11 @@ export default function LoginScreen() {
   const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { signIn } = useAuth();
+  const toast = useToast();
 
   const handleSignIn = async () => {
     if (!email || !password) {
-      Alert.alert('Error', 'Please fill in all fields');
+      toast.error('Please fill in all fields');
       return;
     }
 
@@ -31,7 +32,7 @@ export default function LoginScreen() {
       await signIn(email, password);
       router.replace('/(tabs)');
     } catch (error) {
-      Alert.alert('Sign In Failed', error instanceof Error ? error.message : 'An error occurred');
+      toast.error(error instanceof Error ? error.message : 'Sign in failed');
     } finally {
       setIsLoading(false);
     }

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -1,11 +1,11 @@
 import LinearGradient from '@/components/ui/LinearGradient';
+import { useToast } from '@/components/ToastManager';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
 import {
   ActivityIndicator,
-  Alert,
   KeyboardAvoidingView,
   Platform,
   Text,
@@ -20,20 +20,21 @@ export default function SignupScreen() {
   const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { signUp } = useAuth();
+  const toast = useToast();
 
   const handleSignUp = async () => {
     if (!email || !password || !passwordConfirmation) {
-      Alert.alert('Error', 'Please fill in all fields');
+      toast.error('Please fill in all fields');
       return;
     }
 
     if (password !== passwordConfirmation) {
-      Alert.alert('Error', 'Passwords do not match');
+      toast.error('Passwords do not match');
       return;
     }
 
     if (password.length < 6) {
-      Alert.alert('Error', 'Password must be at least 6 characters long');
+      toast.error('Password must be at least 6 characters long');
       return;
     }
 
@@ -42,7 +43,7 @@ export default function SignupScreen() {
       await signUp(email, password, passwordConfirmation);
       router.replace('/(tabs)');
     } catch (error) {
-      Alert.alert('Sign Up Failed', error instanceof Error ? error.message : 'An error occurred');
+      toast.error(error instanceof Error ? error.message : 'Sign up failed');
     } finally {
       setIsLoading(false);
     }

--- a/app/profile/index.tsx
+++ b/app/profile/index.tsx
@@ -34,7 +34,7 @@ export default function ProfileScreen() {
     try {
       await updateProfile.mutateAsync(formData);
     } catch {
-      Alert.alert('Error', 'Failed to update profile. Please try again.');
+      // apiRequest interceptor surfaces the error toast
     } finally {
       setEditing(false);
     }

--- a/app/smartGoals/index.tsx
+++ b/app/smartGoals/index.tsx
@@ -1,6 +1,7 @@
 import AiOnboardingWizard from '@/components/AiOnboardingWizard';
 import { PrimaryButton } from '@/components/buttons/';
 import { LoadingSpinner } from '@/components/loading';
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useSmartGoals } from '@/hooks/useSmartGoals';
@@ -8,12 +9,13 @@ import { useProfile } from '@/hooks/useUser';
 import { Ionicons } from '@expo/vector-icons';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
-import { Alert, Pressable, Text, View } from 'react-native';
+import { Pressable, Text, View } from 'react-native';
 
 export default function SmartGoalsScreen() {
   const { data: profile, isLoading: profileLoading } = useProfile();
   const { data: goals, isLoading: goalsLoading, error } = useSmartGoals();
   const [showWizard, setShowWizard] = useState(false);
+  const toast = useToast();
 
   const handleStartOnboarding = () => {
     setShowWizard(true);
@@ -183,7 +185,7 @@ export default function SmartGoalsScreen() {
         className="border-2 border-[#33CFFF] rounded-xl py-3 px-4 items-center"
         onPress={() => {
           // TODO: Navigate to edit goal screen
-          Alert.alert('Edit Goal', 'Edit functionality coming soon!');
+          toast.info('Edit functionality coming soon!');
         }}
       >
         <Text className="text-[#33CFFF] font-semibold text-base">Edit Goal</Text>

--- a/app/support-feedback/index.tsx
+++ b/app/support-feedback/index.tsx
@@ -1,4 +1,5 @@
 import { createTicket, DiagnosticsData, TicketData } from '@/api/tickets';
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
@@ -7,7 +8,7 @@ import * as Application from 'expo-application';
 import * as Device from 'expo-device';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
-import { Alert, KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
+import { KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
 
 type TicketKind = 'bug' | 'feedback';
 
@@ -19,6 +20,7 @@ interface FormData {
 
 export default function SupportFeedbackScreen() {
   const { user } = useAuth();
+  const toast = useToast();
   const [selectedKind, setSelectedKind] = useState<TicketKind>('bug');
   const [formData, setFormData] = useState<FormData>({
     kind: 'bug',
@@ -48,7 +50,7 @@ export default function SupportFeedbackScreen() {
 
   const handleSubmit = async () => {
     if (!formData.title.trim() || !formData.description.trim()) {
-      Alert.alert('Missing Information', 'Please fill in both title and description.');
+      toast.error('Please fill in both title and description.');
       return;
     }
 
@@ -65,18 +67,10 @@ export default function SupportFeedbackScreen() {
       const diagnostics = getDiagnostics();
       await createTicket(ticketData, diagnostics);
 
-      Alert.alert(
-        'Thank You!',
-        'Your submission has been received. We\'ll review it and get back to you soon.',
-        [
-          {
-            text: 'OK',
-            onPress: () => router.back()
-          }
-        ]
-      );
+      toast.success('Thank you! Your submission has been received.');
+      router.back();
     } catch {
-      Alert.alert('Error', 'Failed to submit your request. Please try again.');
+      // apiRequest interceptor surfaces the error toast
     } finally {
       setIsSubmitting(false);
     }

--- a/app/taskDetail/[id].tsx
+++ b/app/taskDetail/[id].tsx
@@ -1,6 +1,7 @@
 import { UpdateTaskParams } from '@/api/tasks';
 import { PRIORITY_OPTIONS, PriorityInput } from '@/components/inputs';
 import { LoadingSpinner } from '@/components/loading';
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useDeleteTask, useTask, useUpdateTask } from '@/hooks/useTasks';
@@ -22,6 +23,7 @@ export default function TaskDetailScreen() {
 
   const updateTaskMutation = useUpdateTask();
   const deleteTaskMutation = useDeleteTask();
+  const toast = useToast();
 
   // Fetch task details
   const { data: task, isLoading, error, refetch } = useTask(taskId);
@@ -40,7 +42,7 @@ export default function TaskDetailScreen() {
 
   const handleSave = () => {
     if (!taskDetails.title.trim()) {
-      Alert.alert('Error', 'Title is required');
+      toast.error('Title is required');
       return;
     }
 
@@ -56,10 +58,7 @@ export default function TaskDetailScreen() {
       {
         onSuccess: () => {
           setIsEditing(false);
-          Alert.alert('Success', 'Task updated successfully');
-        },
-        onError: (error) => {
-          Alert.alert('Error', error instanceof Error ? error.message : 'Failed to update task');
+          toast.success('Task updated successfully');
         },
       }
     );
@@ -78,9 +77,6 @@ export default function TaskDetailScreen() {
             deleteTaskMutation.mutate(taskId, {
               onSuccess: () => {
                 router.back();
-              },
-              onError: (error) => {
-                Alert.alert('Error', error instanceof Error ? error.message : 'Failed to delete task');
               },
             });
           },

--- a/components/AiOnboardingWizard.tsx
+++ b/components/AiOnboardingWizard.tsx
@@ -1,4 +1,5 @@
 import { Profile, ProfileUpdateData } from '@/api/users';
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useAiResponseHelpers } from '@/hooks/useAi';
@@ -7,7 +8,7 @@ import { useCreateMultipleSmartGoals } from '@/hooks/useSmartGoals';
 import { useCompleteOnboarding, useProfile, useUpdateProfile } from '@/hooks/useUser';
 import { router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
-import { Alert, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { AiResponseStep, ConfirmationStep, GoalDescriptionStep, ProfileDetailsStep } from './AiOnboardingWizardSteps';
 import ProgressBar from './ProgressBar';
@@ -53,6 +54,7 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
   const createMultipleSmartGoals = useCreateMultipleSmartGoals();
   const completeOnboarding = useCompleteOnboarding()
   const { isSmartGoalResponse, formatMultiPeriodSmartGoalResponse } = useAiResponseHelpers();
+  const toast = useToast();
 
   // Handle completed job results
   useEffect(() => {
@@ -98,7 +100,7 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
 
   const handleSubmitProfileDetails = async () => {
     if (!profileData.first_name?.trim() || !profileData.last_name?.trim() || !profileData.work_role?.trim() || !profileData.education?.trim()) {
-      Alert.alert('Missing Information', 'Please fill in all required fields (First Name, Last Name, Work Role, and Education).');
+      toast.error('Please fill in all required fields (First Name, Last Name, Work Role, and Education).');
       return;
     }
 
@@ -112,7 +114,7 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
       await updateProfile.mutateAsync(profileData);
       setCurrentStepIndex(1);
     } catch {
-      Alert.alert('Error', 'Failed to update your profile details. Please try again.');
+      // apiRequest interceptor surfaces the error toast
     } finally {
       setIsLoading(false);
     }
@@ -120,7 +122,7 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
 
   const handleSubmitGoalDescription = async () => {
     if (!goalDescription.trim()) {
-      Alert.alert('Missing Description', 'Please describe what you want to achieve.');
+      toast.error('Please describe what you want to achieve.');
       return;
     }
 
@@ -129,13 +131,13 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
       await aiProxy.processAiRequest(goalDescription.trim());
       setCurrentStepIndex(2);
     } catch {
-      Alert.alert('Error', 'Failed to generate your SMART goal. Please try again.');
+      // apiRequest interceptor surfaces the error toast
     }
   };
 
   const handleConfirmGoal = async () => {
     if (!aiResponse || !isSmartGoalResponse(aiResponse)) {
-      Alert.alert('Error', 'Invalid goal data. Please try again.');
+      toast.error('Invalid goal data. Please try again.');
       return;
     }
 
@@ -176,7 +178,7 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
       onComplete();
       router.replace('/(tabs)');
     } catch {
-      Alert.alert('Error', 'Failed to save your goals. Please try again.');
+      // apiRequest interceptor surfaces the error toast
     }
   };
 

--- a/components/NotificationSettings.tsx
+++ b/components/NotificationSettings.tsx
@@ -1,7 +1,7 @@
 import { useNotificationPreferences } from '@/hooks/useNotificationPreferences';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useEffect, useState } from 'react';
-import { Alert, Modal, Pressable, ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
+import { Modal, Pressable, ScrollView, Switch, Text, TouchableOpacity, View } from 'react-native';
 import { LoadingSkeleton } from './loading';
 
 const HOURS = [
@@ -79,10 +79,9 @@ const NotificationSettings = () => {
     try {
       await updatePreferences({ push_enabled: value });
     } catch {
-      // Revert on error
+      // Revert on error — apiRequest interceptor surfaces the toast
       setPushEnabled(!value);
       setDailyReminderEnabled(!value);
-      Alert.alert('Error', 'Failed to update notification preferences');
     }
   };
 
@@ -95,9 +94,9 @@ const NotificationSettings = () => {
       try {
         await updatePreferences({ push_enabled: true });
       } catch {
+        // Revert on error — apiRequest interceptor surfaces the toast
         setPushEnabled(false);
         setDailyReminderEnabled(false);
-        Alert.alert('Error', 'Failed to update notification preferences');
       }
     }
   };
@@ -113,10 +112,9 @@ const NotificationSettings = () => {
       const timeString = formatTimeForAPI(hour, period);
       await updatePreferences({ preferred_time: timeString });
     } catch {
-      // Revert on error
+      // Revert on error — apiRequest interceptor surfaces the toast
       setSelectedHour(prevHour);
       setSelectedPeriod(prevPeriod);
-      Alert.alert('Error', 'Failed to update reminder time');
     }
   };
 

--- a/components/OpenAiApiKeyInput.tsx
+++ b/components/OpenAiApiKeyInput.tsx
@@ -1,4 +1,5 @@
 import { LoadingSkeleton, LoadingSpinner } from '@/components/loading';
+import { useToast } from '@/components/ToastManager';
 import { useAiSettings } from '@/hooks/useAiSettings';
 import { Ionicons } from '@expo/vector-icons';
 import React, { useEffect, useState } from 'react';
@@ -15,6 +16,7 @@ const OpenAIApiKeyInput = () => {
     isLoading,
     error
   } = useAiSettings();
+  const toast = useToast();
 
   const [inputKey, setInputKey] = useState('');
   const [isEditing, setIsEditing] = useState(false);
@@ -40,7 +42,7 @@ const OpenAIApiKeyInput = () => {
 
   const handleSaveKey = async () => {
     if (!inputKey.trim()) {
-      Alert.alert('Error', 'Please enter a valid API key');
+      toast.error('Please enter a valid API key');
       return;
     }
 
@@ -48,9 +50,9 @@ const OpenAIApiKeyInput = () => {
       await setApiKey(inputKey.trim());
       setStoredApiKey(inputKey.trim());
       setIsEditing(false);
-      Alert.alert('Success', 'Your API key has been saved securely');
+      toast.success('Your API key has been saved securely');
     } catch {
-      Alert.alert('Error', 'Failed to save API key. Please try again.');
+      toast.error('Failed to save API key. Please try again.');
     }
   }
 
@@ -68,9 +70,9 @@ const OpenAIApiKeyInput = () => {
               await clearApiKey();
               setStoredApiKey(null);
               setInputKey('');
-              Alert.alert('Success', 'API key cleared');
+              toast.success('API key cleared');
             } catch {
-              Alert.alert('Error', 'Failed to clear API key');
+              toast.error('Failed to clear API key');
             }
           },
         },

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import { Text, View } from 'react-native'
+import { Ionicons } from '@expo/vector-icons'
+import { IconButton } from './buttons'
+
+export type ToastVariant = 'success' | 'error' | 'info'
+
+export interface ToastData {
+  id: string
+  message: string
+  variant: ToastVariant
+}
+
+interface ToastProps {
+  toast: ToastData
+  onDismiss: (id: string) => void
+}
+
+const VARIANT_STYLES: Record<ToastVariant, { bg: string; icon: keyof typeof Ionicons.glyphMap; iconColor: string }> = {
+  success: { bg: 'bg-emerald-500', icon: 'checkmark-circle', iconColor: '#ffffff' },
+  error: { bg: 'bg-red-500', icon: 'alert-circle', iconColor: '#ffffff' },
+  info: { bg: 'bg-cyan-500', icon: 'information-circle', iconColor: '#ffffff' },
+}
+
+export default function Toast({ toast, onDismiss }: ToastProps) {
+  const { bg, icon, iconColor } = VARIANT_STYLES[toast.variant]
+
+  return (
+    <View
+      className={`flex-row items-center px-4 py-3 mx-4 mb-2 rounded-xl shadow-md ${bg}`}
+      testID={`toast-${toast.variant}`}
+    >
+      <Ionicons name={icon} size={22} color={iconColor} />
+      <Text className="flex-1 ml-3 text-white text-base font-medium" testID="toast-message">
+        {toast.message}
+      </Text>
+      <IconButton
+        icon={<Ionicons name="close" size={20} color={iconColor} />}
+        onPress={() => onDismiss(toast.id)}
+        accessibilityLabel="Dismiss notification"
+        testID="toast-dismiss"
+        className="ml-2 p-1"
+      />
+    </View>
+  )
+}

--- a/components/Toast.tsx
+++ b/components/Toast.tsx
@@ -1,6 +1,6 @@
+import { Ionicons } from '@expo/vector-icons'
 import React from 'react'
 import { Text, View } from 'react-native'
-import { Ionicons } from '@expo/vector-icons'
 import { IconButton } from './buttons'
 
 export type ToastVariant = 'success' | 'error' | 'info'
@@ -31,7 +31,7 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
       testID={`toast-${toast.variant}`}
     >
       <Ionicons name={icon} size={22} color={iconColor} />
-      <Text className="flex-1 ml-3 text-white text-base font-medium" testID="toast-message">
+      <Text className="flex-1 ml-3 text-base font-medium text-white" testID="toast-message">
         {toast.message}
       </Text>
       <IconButton
@@ -39,7 +39,7 @@ export default function Toast({ toast, onDismiss }: ToastProps) {
         onPress={() => onDismiss(toast.id)}
         accessibilityLabel="Dismiss notification"
         testID="toast-dismiss"
-        className="ml-2 p-1"
+        className="p-1 ml-2"
       />
     </View>
   )

--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -80,7 +80,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
       {children}
       <View
         pointerEvents="box-none"
-        className="absolute top-0 left-0 right-0 pt-2"
+        className="absolute right-0 left-0 top-16 pt-2"
         testID="toast-stack"
       >
         {toasts.map((toast) => (
@@ -92,10 +92,10 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
 }
 
 const NOOP_TOAST: ToastApi = {
-  success: () => {},
-  error: () => {},
-  info: () => {},
-  dismiss: () => {},
+  success: () => { },
+  error: () => { },
+  info: () => { },
+  dismiss: () => { },
 }
 
 export function useToast(): ToastApi {

--- a/components/ToastManager.tsx
+++ b/components/ToastManager.tsx
@@ -1,0 +1,103 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react'
+import { View } from 'react-native'
+import Toast, { ToastData, ToastVariant } from './Toast'
+
+interface ToastOptions {
+  durationMs?: number
+}
+
+interface ToastApi {
+  success: (message: string, options?: ToastOptions) => void
+  error: (message: string, options?: ToastOptions) => void
+  info: (message: string, options?: ToastOptions) => void
+  dismiss: (id: string) => void
+}
+
+const DEFAULT_DURATION_MS = 4000
+const MAX_VISIBLE = 3
+
+const ToastContext = createContext<ToastApi | null>(null)
+
+let externalToastApi: ToastApi | null = null
+
+export function getToastApi(): ToastApi | null {
+  return externalToastApi
+}
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<ToastData[]>([])
+  const timers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const dismiss = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id))
+    const timer = timers.current.get(id)
+    if (timer) {
+      clearTimeout(timer)
+      timers.current.delete(id)
+    }
+  }, [])
+
+  const show = useCallback(
+    (variant: ToastVariant, message: string, options?: ToastOptions) => {
+      const id = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`
+      setToasts((prev) => [...prev, { id, message, variant }].slice(-MAX_VISIBLE))
+      const duration = options?.durationMs ?? DEFAULT_DURATION_MS
+      const timer = setTimeout(() => dismiss(id), duration)
+      timers.current.set(id, timer)
+    },
+    [dismiss],
+  )
+
+  const api = useMemo<ToastApi>(
+    () => ({
+      success: (message, options) => show('success', message, options),
+      error: (message, options) => show('error', message, options),
+      info: (message, options) => show('info', message, options),
+      dismiss,
+    }),
+    [show, dismiss],
+  )
+
+  useEffect(() => {
+    externalToastApi = api
+    return () => {
+      if (externalToastApi === api) {
+        externalToastApi = null
+      }
+    }
+  }, [api])
+
+  useEffect(() => {
+    const currentTimers = timers.current
+    return () => {
+      currentTimers.forEach((timer) => clearTimeout(timer))
+      currentTimers.clear()
+    }
+  }, [])
+
+  return (
+    <ToastContext.Provider value={api}>
+      {children}
+      <View
+        pointerEvents="box-none"
+        className="absolute top-0 left-0 right-0 pt-2"
+        testID="toast-stack"
+      >
+        {toasts.map((toast) => (
+          <Toast key={toast.id} toast={toast} onDismiss={dismiss} />
+        ))}
+      </View>
+    </ToastContext.Provider>
+  )
+}
+
+const NOOP_TOAST: ToastApi = {
+  success: () => {},
+  error: () => {},
+  info: () => {},
+  dismiss: () => {},
+}
+
+export function useToast(): ToastApi {
+  return useContext(ToastContext) ?? NOOP_TOAST
+}

--- a/components/buttons/IconButton.tsx
+++ b/components/buttons/IconButton.tsx
@@ -1,0 +1,33 @@
+import React from 'react'
+import { TouchableOpacity } from 'react-native'
+
+interface IconButtonProps {
+  icon: React.ReactNode
+  onPress: () => void
+  disabled?: boolean
+  className?: string
+  accessibilityLabel?: string
+  testID?: string
+}
+
+export default function IconButton({
+  icon,
+  onPress,
+  disabled = false,
+  className = '',
+  accessibilityLabel,
+  testID = 'icon-button',
+}: IconButtonProps) {
+  return (
+    <TouchableOpacity
+      className={`items-center justify-center ${className}`}
+      onPress={onPress}
+      disabled={disabled}
+      accessibilityRole="button"
+      accessibilityLabel={accessibilityLabel}
+      testID={testID}
+    >
+      {icon}
+    </TouchableOpacity>
+  )
+}

--- a/components/buttons/index.ts
+++ b/components/buttons/index.ts
@@ -1,3 +1,4 @@
 export { default as PrimaryButton } from "./PrimaryButton";
 export { default as SecondaryButton } from "./SecondaryButton";
+export { default as IconButton } from "./IconButton";
 

--- a/hooks/useGoalCreation.ts
+++ b/hooks/useGoalCreation.ts
@@ -1,6 +1,6 @@
 import { router } from 'expo-router';
 import { useState } from 'react';
-import { Alert } from 'react-native';
+import { useToast } from '../components/ToastManager';
 import {
   formatTimeframeForAiResponse,
   getServerTimeframe,
@@ -30,6 +30,7 @@ export interface GoalCreationActions {
 export const useGoalCreation = (): GoalCreationActions & GoalCreationState => {
   const { mutateAsync: createSmartGoal } = useCreateSmartGoal();
   const { processAiRequest, isLoading, aiResponse } = useAiProxy();
+  const toast = useToast();
 
   const [goalDescription, setGoalDescription] = useState('');
   const [selectedTimeframe, setSelectedTimeframe] = useState('');
@@ -38,15 +39,15 @@ export const useGoalCreation = (): GoalCreationActions & GoalCreationState => {
   const handleCreateGoal = async (): Promise<void> => {
     const validation = validateGoalData(goalDescription, selectedTimeframe);
     if (!validation.isValid) {
-      Alert.alert('Error', validation.errorMessage);
+      toast.error(validation.errorMessage ?? 'Invalid goal data');
       return;
     }
 
     try {
       await processAiRequest(goalDescription, selectedTimeframe);
       setShowConfirmation(true);
-    } catch (error) {
-      Alert.alert('Error', 'Failed to create goal. Please try again.');
+    } catch {
+      // apiRequest interceptor surfaces the error toast
     }
   };
 
@@ -70,18 +71,13 @@ export const useGoalCreation = (): GoalCreationActions & GoalCreationState => {
         time_bound: formattedResponse.time_bound
       });
 
-      Alert.alert(
-        'Success!',
-        'Your SMART goal has been created successfully.',
-        [
-          {
-            text: 'OK',
-            onPress: () => router.back()
-          }
-        ]
-      );
+      toast.success('Your SMART goal has been created successfully.');
+      router.back();
     } catch (error) {
-      Alert.alert('Error', 'Failed to save goal. Please try again.');
+      // apiRequest interceptor surfaces API error toasts; surface non-API failures (e.g., missing aiResponse)
+      if (error instanceof Error && error.message === 'No goal details available') {
+        toast.error(error.message);
+      }
     }
   };
 

--- a/utils/apiRequest.ts
+++ b/utils/apiRequest.ts
@@ -1,9 +1,11 @@
 import { API_BASE_URL } from '../constants/config';
 import { getAuthHeaders } from './api';
+import { getToastApi } from '../components/ToastManager';
 
 export interface ApiRequestOptions extends RequestInit {
   data?: any;
   params?: Record<string, string | number | boolean>;
+  silent?: boolean;
 }
 
 export interface ApiResponse<T> {
@@ -12,20 +14,37 @@ export interface ApiResponse<T> {
   status: number;
 }
 
+const extractErrorMessage = (responseData: any, status: number, statusText: string): string => {
+  return (
+    responseData?.error ||
+    responseData?.status?.message ||
+    responseData?.message ||
+    `HTTP ${status}: ${statusText}`
+  );
+};
+
+const notifyError = (message: string, silent: boolean | undefined) => {
+  if (silent) return;
+  const toast = getToastApi();
+  toast?.error(message);
+};
+
 /**
  * Enhanced API request function with automatic authentication and flexible parameters
- * 
+ *
  * @param endpoint - API endpoint (e.g., '/tasks', '/users')
- * @param options - Request options including data, params, and fetch options
+ * @param options - Request options including data, params, and fetch options.
+ *                  Pass `silent: true` to suppress the auto-error toast on 4xx/5xx
+ *                  (e.g., when rendering the error inline).
  * @returns Promise<ApiResponse<T>>
  */
 export const apiRequest = async <T = any>(
   endpoint: string,
   options: ApiRequestOptions = {}
 ): Promise<ApiResponse<T>> => {
+  const { data, params, silent, ...fetchOptions } = options;
+
   try {
-    const { data, params, ...fetchOptions } = options;
-    
     // Build URL with query parameters
     let url = `${API_BASE_URL}${endpoint}`;
     if (params) {
@@ -38,7 +57,7 @@ export const apiRequest = async <T = any>(
 
     // Get authentication headers
     const authHeaders = await getAuthHeaders();
-    
+
     // Prepare request body
     let body: string | undefined;
     if (data) {
@@ -66,24 +85,28 @@ export const apiRequest = async <T = any>(
     // Check if response has content and is JSON
     const contentType = response.headers.get('content-type');
     const hasContent = contentType && contentType.includes('application/json');
-    
+
     let responseData: any = undefined;
-    
+
     if (hasContent) {
       try {
         responseData = await response.json();
       } catch (parseError) {
         console.error('JSON parse error:', parseError);
+        const message = 'Invalid JSON response from server';
+        notifyError(message, silent);
         return {
-          error: 'Invalid JSON response from server',
+          error: message,
           status: response.status,
         };
       }
     }
 
     if (!response.ok) {
+      const message = extractErrorMessage(responseData, response.status, response.statusText);
+      notifyError(message, silent);
       return {
-        error: responseData?.error || `HTTP ${response.status}: ${response.statusText}`,
+        error: message,
         status: response.status,
       };
     }
@@ -93,8 +116,10 @@ export const apiRequest = async <T = any>(
       status: response.status,
     };
   } catch (error) {
+    const message = error instanceof Error ? error.message : 'Network error';
+    notifyError(message, silent);
     return {
-      error: error instanceof Error ? error.message : 'Network error',
+      error: message,
       status: 0,
     };
   }
@@ -116,4 +141,4 @@ export const apiPatch = <T = any>(endpoint: string, data?: any) =>
   apiRequest<T>(endpoint, { method: 'PATCH', data });
 
 export const apiDelete = <T = any>(endpoint: string) =>
-  apiRequest<T>(endpoint, { method: 'DELETE' }); 
+  apiRequest<T>(endpoint, { method: 'DELETE' });


### PR DESCRIPTION
## Summary
Lands PC-F1: a global toast system that becomes the single source of feedback for every async action across the app. Adds `Toast` + `ToastManager` components (provider + `useToast()` hook + module-level handle for non-React callers), a new `IconButton` primitive used as the toast's dismiss button, and an interceptor in `utils/apiRequest.ts` that fires an error toast automatically on every 4xx/5xx (and network error) — with `silent: true` opt-out for inline rendering.

Migrates 41 of 45 `Alert.alert` call sites to `useToast`. The four remaining are true confirmation dialogs (delete task, sign-out, cancel-edit, clear API key) — toasts intentionally don't carry buttons, so those stay as `Alert.alert`. Where an `Alert.alert` was a manual error report inside an `onError` / `catch` for a mutation that routes through `apiRequest`, the manual call is dropped — the interceptor surfaces the same error once.

### Why
PC-F1 is the foundation for the rest of PC-F (Frontend Reliability Foundations): without a single, consistent feedback surface, validation errors, mutation failures, and recoverable crashes all look different to the user. The auto-error interceptor closes the most common silent-failure path — a screen catching an API error and forgetting to show it.

## Changes
- `components/buttons/IconButton.tsx`, `components/buttons/index.ts`
  - New shared `IconButton` (icon + `onPress`); used as the toast dismiss button. Built on `TouchableOpacity` to match the existing button conventions.
- `components/Toast.tsx`
  - Single toast UI with `success` / `error` / `info` variants; renders message + `IconButton` (X) for manual dismiss.
- `components/ToastManager.tsx`
  - `<ToastProvider>`, `useToast()` hook returning `{ success, error, info, dismiss }`, plus a `getToastApi()` module-level handle so non-React callers (the API client interceptor) can fire toasts. Caps visible toasts at 3, default duration 4s, auto-dismiss timers cleaned up on unmount. `useToast()` returns a no-op fallback when no provider is mounted, so unit tests that don't wrap their render don't blow up.
- `app/_layout.tsx`
  - Mounts `<ToastProvider>` inside `SafeAreaView` so the toast stack overlays every screen.
- `utils/apiRequest.ts`
  - Adds `silent?: boolean` to `ApiRequestOptions`. Surfaces an error toast on non-2xx (excluding 401, which already routes through auth) and on network errors via `getToastApi()`. Extracts the error message from `responseData.error`, `responseData.status.message`, `responseData.message`, or falls back to `HTTP <status>: <statusText>`.
- `app/auth/login.tsx`, `app/auth/signup.tsx`, `app/(tabs)/index.tsx`, `app/(tabs)/menu.tsx`, `app/(tabs)/todaysFocus.tsx`, `app/addTask/index.tsx`, `app/profile/index.tsx`, `app/smartGoals/index.tsx`, `app/support-feedback/index.tsx`, `app/taskDetail/[id].tsx`, `components/AiOnboardingWizard.tsx`, `components/NotificationSettings.tsx`, `components/OpenAiApiKeyInput.tsx`, `hooks/useGoalCreation.ts`
  - `Alert.alert('Error', ...)` → `toast.error(...)`, `Alert.alert('Success', ...)` → `toast.success(...)`. Manual error toasts inside mutation `onError` / `catch` are dropped where the `apiRequest` interceptor covers them. Single-OK alerts that ran a callback (e.g., `router.back()`) become `toast.success(...)` followed by the callback inline. Confirm dialogs (delete task, sign-out, cancel-edit, clear API key) stay as `Alert.alert`.
- `__tests__/hooks/useGoalCreation.test.tsx`, `__tests__/screens/AddTaskScreen.test.tsx`, `__tests__/screens/HomeScreen.test.tsx`, `__tests__/screens/LoginScreen.test.tsx`, `__tests__/screens/SettingsScreen.test.tsx`, `__tests__/screens/SignupScreen.test.tsx`, `__tests__/screens/TodaysFocusScreen.test.tsx`
  - Replace `Alert.alert` mocks/assertions with `useToast` mocks asserting on `mockToastError`. Drop `onError: expect.any(Function)` from mutation-call assertions where the screen no longer passes it. Two TodaysFocusScreen tests that asserted screen-level error alerts now assert graceful recovery (the mock was called, no UI feedback expected).
- `README.md`
  - Documents the toast convention: `useToast()` API, the `silent: true` opt-out, when to keep `Alert.alert` (confirm dialogs only).

## Test Plan
- [x] `npm run typecheck` — clean
- [x] `npm test` — 364/364 pass (37 suites)
- [ ] Manual: trigger a 4xx response (e.g., submit an empty form to a server-validated endpoint) and confirm a single error toast appears via the interceptor
- [ ] Manual: confirm dismiss button (X) closes the toast immediately
- [ ] Manual: confirm multiple rapid toasts cap at 3 visible and auto-dismiss after 4s
- [ ] Manual: confirm the four kept `Alert.alert` confirm dialogs (delete task, sign-out, cancel-edit, clear API key) still show as native dialogs

## Additional Notes
- `utils/api.ts` (the older throw-style API helper used by a small number of legacy callers) is intentionally not wired into the interceptor — it's on the way out, and adding parallel toast logic there would muddy two paths. Callers using the older helper still throw, and screens can call `toast.error()` manually if needed.
- PC-F2 (`react-hook-form` + `zod`) and PC-F3 (error boundaries) are unblocked by this PR.