### PR TITLE
feat: frontend reliability foundations (PC-F2 + PC-F3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,3 +39,156 @@ await apiPost('/tasks', { ... }, { silent: true });
 - **Keep `Alert.alert`** only for true confirmation dialogs — anything that
   needs the user to choose between actions (Cancel / Delete, Continue / Discard,
   etc.). Toasts intentionally don't carry buttons.
+
+## Forms
+
+The project uses [`react-hook-form`](https://react-hook-form.com/) with
+[`zod`](https://zod.dev/) for schema-based validation. Every form goes through
+this stack — no ad-hoc `useState` / inline `if (!field) toast.error(...)`.
+
+### Domain models vs. form schemas
+
+Canonical domain schemas live in `models/`, one per resource (`profile.ts`,
+`task.ts`, `smartGoal.ts`, `auth.ts`). They mirror the API response shape and
+serve as the source of truth for any form that touches that resource.
+
+Form schemas live next to the form (the screen or component file) and are
+**derived from the model** via `.pick()` / `.omit()` / `.extend()`. This keeps
+form-specific concerns (extra fields, different requiredness) local while
+preserving the shared truth in `models/`.
+
+```tsx
+// models/task.ts — canonical, shared
+export const taskSchema = z.object({
+  id: z.number().int().positive().optional(),
+  title: z.string().trim().min(1, 'Title is required').max(200),
+  // ...
+});
+
+// app/addTask/index.tsx — co-located form schema
+const addTaskFormSchema = taskSchema.pick({
+  title: true,
+  description: true,
+  priority: true,
+  action_category: true,
+});
+type AddTaskFormValues = z.infer<typeof addTaskFormSchema>;
+```
+
+For onboarding-style forms where requiredness differs from the domain model,
+use `.extend({...})` to override:
+
+```tsx
+const onboardingProfileSchema = profileSchema
+  .pick({ first_name: true, last_name: true, /* ... */ })
+  .extend({
+    first_name: z.string().trim().min(1, 'First name is required').max(100),
+    last_name: z.string().trim().min(1, 'Last name is required').max(100),
+  });
+```
+
+### Wiring up react-hook-form
+
+Inputs in React Native need to be wrapped in `Controller` (`TextInput` is
+uncontrolled by RHF's default `register` API):
+
+```tsx
+import { Controller, useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const { control, handleSubmit, formState: { errors, isValid } } =
+  useForm<AddTaskFormValues>({
+    resolver: zodResolver(addTaskFormSchema),
+    mode: 'onTouched',
+    defaultValues: { title: '', /* ... */ },
+  });
+
+<Controller
+  control={control}
+  name="title"
+  render={({ field: { value, onChange, onBlur } }) => (
+    <TextInput
+      value={value}
+      onChangeText={onChange}
+      onBlur={onBlur}
+      testID="add-task-task-name-input"
+    />
+  )}
+/>
+{errors.title && (
+  <Text testID="add-task-task-name-error">{errors.title.message}</Text>
+)}
+
+<PrimaryButton
+  onPress={handleSubmit(onSubmit)}
+  disabled={!isValid || mutation.isPending}
+/>
+```
+
+### Conventions
+
+- **Submit disabled while invalid.** Bind the submit button's `disabled` to
+  `!isValid` (plus any pending mutation flag). The button still fires the
+  resolver on press if somehow reached — `handleSubmit` won't call your
+  handler with invalid values.
+- **Validation modes.** Use `mode: 'onTouched'` so errors show after a field
+  blurs once (not on every keystroke before the user has had a chance).
+- **Server errors flow through the toast system.** Don't duplicate
+  field-level error rendering for server failures — `apiRequest` already
+  surfaces an error toast. Only render inline errors for client-side
+  validation. If you genuinely need to render a server error inline, pass
+  `silent: true` to the API call to suppress the auto-toast.
+- **`testID` on every input and error.** Tests rely on these. Use a
+  consistent `<scope>-<field>-input` / `<scope>-<field>-error` pattern.
+
+## Error boundaries
+
+Recoverable error boundaries wrap high-risk screens so an unhandled render
+error shows a fallback with a retry CTA instead of a white screen.
+
+```tsx
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+
+export default function TaskDetailScreen() {
+  const queryClient = useQueryClient();
+  return (
+    <ErrorBoundary
+      scope="task-detail"
+      onReset={() => queryClient.invalidateQueries({ queryKey: ['tasks'] })}
+    >
+      <TaskDetailContent />
+    </ErrorBoundary>
+  );
+}
+
+function TaskDetailContent() { /* hooks + JSX */ }
+```
+
+### What gets wrapped
+
+- Root tab navigator (`app/(tabs)/_layout.tsx`)
+- Detail screens that depend on a query that could fail mid-render
+  (`app/taskDetail/[id].tsx`, `app/smartGoals/index.tsx`)
+- AI-driven flows (`app/onboarding.tsx`, `app/addGoal/index.tsx`) — these
+  parse external responses and have more failure surface
+
+### Conventions
+
+- **Extract content into an inner component.** Most screens have multiple
+  return paths (loading / error / data). Wrap a single inner component
+  rather than every branch.
+- **`onReset` should refetch.** When the user taps Retry, reset the
+  underlying React Query state with `queryClient.invalidateQueries(...)` so
+  the screen actually retries the failed request, not just remounts the
+  same broken state.
+- **Use `scope` on every boundary.** It's passed to the error reporter
+  (`utils/reportError.ts`) for triage.
+- **Don't wrap entire trees.** Granular boundaries are more recoverable —
+  the ticket guidance is "two taps to recover, not a full app restart".
+
+### Error reporting
+
+`utils/reportError.ts` is a thin Sentry-aware shim. Sentry isn't wired up
+yet; the helper currently logs to `console.error` and forwards to a global
+`Sentry.captureException` if one is registered. When Sentry is added,
+swap the implementation in this one file.

--- a/__tests__/hooks/useGoalCreation.test.tsx
+++ b/__tests__/hooks/useGoalCreation.test.tsx
@@ -70,31 +70,9 @@ describe('useGoalCreation', () => {
   it('should initialize with default state', () => {
     const { result } = renderHook(() => useGoalCreation());
 
-    expect(result.current.goalDescription).toBe('');
-    expect(result.current.selectedTimeframe).toBe('');
     expect(result.current.showConfirmation).toBe(false);
     expect(result.current.isLoading).toBe(false);
     expect(result.current.aiResponse).toBe(null);
-  });
-
-  it('should update goal description', () => {
-    const { result } = renderHook(() => useGoalCreation());
-
-    act(() => {
-      result.current.setGoalDescription('Learn React Native');
-    });
-
-    expect(result.current.goalDescription).toBe('Learn React Native');
-  });
-
-  it('should update selected timeframe', () => {
-    const { result } = renderHook(() => useGoalCreation());
-
-    act(() => {
-      result.current.setSelectedTimeframe('3 months');
-    });
-
-    expect(result.current.selectedTimeframe).toBe('3 months');
   });
 
   it('should update show confirmation', () => {
@@ -108,50 +86,15 @@ describe('useGoalCreation', () => {
   });
 
   describe('handleCreateGoal', () => {
-    it('should call processAiRequest when validation passes', async () => {
+    it('should call processAiRequest with provided values', async () => {
       const { result } = renderHook(() => useGoalCreation());
 
-      act(() => {
-        result.current.setGoalDescription('Learn React Native');
-        result.current.setSelectedTimeframe('3 months');
-      });
-
       await act(async () => {
-        await result.current.handleCreateGoal();
+        await result.current.handleCreateGoal('Learn React Native', '3 months');
       });
 
       expect(mockProcessAiRequest).toHaveBeenCalledWith('Learn React Native', '3 months');
       expect(result.current.showConfirmation).toBe(true);
-    });
-
-    it('should show error alert when goal description is empty', async () => {
-      const { result } = renderHook(() => useGoalCreation());
-
-      act(() => {
-        result.current.setSelectedTimeframe('3 months');
-      });
-
-      await act(async () => {
-        await result.current.handleCreateGoal();
-      });
-
-      expect(mockToastError).toHaveBeenCalledWith('Please enter a goal description');
-      expect(mockProcessAiRequest).not.toHaveBeenCalled();
-    });
-
-    it('should show error alert when timeframe is not selected', async () => {
-      const { result } = renderHook(() => useGoalCreation());
-
-      act(() => {
-        result.current.setGoalDescription('Learn React Native');
-      });
-
-      await act(async () => {
-        await result.current.handleCreateGoal();
-      });
-
-      expect(mockToastError).toHaveBeenCalledWith('Please select a timeframe');
-      expect(mockProcessAiRequest).not.toHaveBeenCalled();
     });
 
     it('should not throw when AI request fails (interceptor surfaces toast)', async () => {
@@ -159,13 +102,8 @@ describe('useGoalCreation', () => {
 
       mockProcessAiRequest.mockRejectedValue(new Error('AI request failed'));
 
-      act(() => {
-        result.current.setGoalDescription('Learn React Native');
-        result.current.setSelectedTimeframe('3 months');
-      });
-
       await act(async () => {
-        await result.current.handleCreateGoal();
+        await result.current.handleCreateGoal('Learn React Native', '3 months');
       });
 
       expect(mockProcessAiRequest).toHaveBeenCalled();
@@ -201,13 +139,8 @@ describe('useGoalCreation', () => {
 
       const { result } = renderHook(() => useGoalCreation());
 
-      act(() => {
-        result.current.setGoalDescription('Learn React Native');
-        result.current.setSelectedTimeframe('3 months');
-      });
-
       await act(async () => {
-        await result.current.handleConfirmGoal();
+        await result.current.handleConfirmGoal('Learn React Native', '3 months');
       });
 
       expect(mockCreateSmartGoal).toHaveBeenCalledWith({
@@ -226,7 +159,7 @@ describe('useGoalCreation', () => {
       const { result } = renderHook(() => useGoalCreation());
 
       await act(async () => {
-        await result.current.handleConfirmGoal();
+        await result.current.handleConfirmGoal('Learn React Native', '3 months');
       });
 
       expect(mockToastError).toHaveBeenCalledWith('No goal details available');

--- a/__tests__/screens/AddTaskScreen.test.tsx
+++ b/__tests__/screens/AddTaskScreen.test.tsx
@@ -93,6 +93,10 @@ describe('AddTaskScreen', () => {
 
     fireEvent.changeText(titleInput, 'Test Task');
     fireEvent.changeText(descriptionInput, 'Test Description');
+
+    await waitFor(() => {
+      expect(submitButton.props.accessibilityState?.disabled).toBe(false);
+    });
     fireEvent.press(submitButton);
 
     await waitFor(() => {
@@ -205,7 +209,15 @@ describe('AddTaskScreen', () => {
     const submitButton = screen.getByTestId('add-task-add-button');
 
     fireEvent.changeText(titleInput, 'Test Task');
+
+    await waitFor(() => {
+      expect(submitButton.props.accessibilityState?.disabled).toBe(false);
+    });
     fireEvent.press(submitButton);
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalled();
+    });
 
     // Get the onSuccess callback from the mutation call
     const onSuccessCallback = mockMutate.mock.calls[0][1]?.onSuccess;

--- a/__tests__/screens/ForgotPasswordScreen.test.tsx
+++ b/__tests__/screens/ForgotPasswordScreen.test.tsx
@@ -60,14 +60,12 @@ describe('ForgotPasswordScreen', () => {
     expect(screen.getByTestId('forgot-password-back-link')).toBeTruthy();
   });
 
-  it('shows a validation error when the email field is empty', async () => {
+  it('keeps the submit button disabled while the email is empty', () => {
     renderScreen();
 
-    fireEvent.press(screen.getByTestId('forgot-password-submit-button'));
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Please enter your email');
-    });
+    const button = screen.getByTestId('forgot-password-submit-button');
+    expect(button.props.accessibilityState?.disabled).toBe(true);
+    fireEvent.press(button);
     expect(mockRequestPasswordReset).not.toHaveBeenCalled();
   });
 
@@ -76,7 +74,11 @@ describe('ForgotPasswordScreen', () => {
     renderScreen();
 
     fireEvent.changeText(screen.getByTestId('forgot-password-email-input'), 'user@example.com');
-    fireEvent.press(screen.getByTestId('forgot-password-submit-button'));
+    const button = screen.getByTestId('forgot-password-submit-button');
+    await waitFor(() => {
+      expect(button.props.accessibilityState?.disabled).toBe(false);
+    });
+    fireEvent.press(button);
 
     await waitFor(() => {
       expect(mockRequestPasswordReset).toHaveBeenCalledWith('user@example.com');
@@ -96,7 +98,11 @@ describe('ForgotPasswordScreen', () => {
     renderScreen();
 
     fireEvent.changeText(screen.getByTestId('forgot-password-email-input'), 'user@example.com');
-    fireEvent.press(screen.getByTestId('forgot-password-submit-button'));
+    const button = screen.getByTestId('forgot-password-submit-button');
+    await waitFor(() => {
+      expect(button.props.accessibilityState?.disabled).toBe(false);
+    });
+    fireEvent.press(button);
 
     await waitFor(() => {
       expect(mockToastError).toHaveBeenCalledWith('Service unavailable');

--- a/__tests__/screens/LoginScreen.test.tsx
+++ b/__tests__/screens/LoginScreen.test.tsx
@@ -41,6 +41,19 @@ jest.mock('../../hooks/useAuth', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const fillForm = (email: string, password: string) => {
+  fireEvent.changeText(screen.getByTestId('login-email-input'), email);
+  fireEvent.changeText(screen.getByTestId('login-password-input'), password);
+};
+
+const waitForButtonEnabled = async () => {
+  const button = screen.getByTestId('login-signin-button');
+  await waitFor(() => {
+    expect(button.props.accessibilityState?.disabled).toBe(false);
+  });
+  return button;
+};
+
 describe('LoginScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -61,7 +74,7 @@ describe('LoginScreen', () => {
     expect(screen.getByTestId('login-signup-link')).toBeTruthy();
   });
 
-  it('shows validation error when fields are empty', async () => {
+  it('keeps the submit button disabled while fields are empty', () => {
     render(
       <AuthProvider>
         <LoginScreen />
@@ -69,11 +82,9 @@ describe('LoginScreen', () => {
     );
 
     const signInButton = screen.getByTestId('login-signin-button');
+    expect(signInButton.props.accessibilityState?.disabled).toBe(true);
     fireEvent.press(signInButton);
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
-    });
+    expect(mockSignIn).not.toHaveBeenCalled();
   });
 
   it('handles successful sign in', async () => {
@@ -85,12 +96,8 @@ describe('LoginScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('login-email-input');
-    const passwordInput = screen.getByTestId('login-password-input');
-    const signInButton = screen.getByTestId('login-signin-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
+    fillForm('test@example.com', 'password123');
+    const signInButton = await waitForButtonEnabled();
     fireEvent.press(signInButton);
 
     await waitFor(() => {
@@ -108,12 +115,8 @@ describe('LoginScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('login-email-input');
-    const passwordInput = screen.getByTestId('login-password-input');
-    const signInButton = screen.getByTestId('login-signin-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'wrongpassword');
+    fillForm('test@example.com', 'wrongpassword');
+    const signInButton = await waitForButtonEnabled();
     fireEvent.press(signInButton);
 
     await waitFor(() => {
@@ -145,15 +148,10 @@ describe('LoginScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('login-email-input');
-    const passwordInput = screen.getByTestId('login-password-input');
-    const signInButton = screen.getByTestId('login-signin-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
+    fillForm('test@example.com', 'password123');
+    const signInButton = await waitForButtonEnabled();
     fireEvent.press(signInButton);
 
-    // Check that loading indicator appears
     await waitFor(() => {
       expect(screen.getByTestId('login-loading-indicator')).toBeTruthy();
     });
@@ -168,39 +166,27 @@ describe('LoginScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('login-email-input');
-    const passwordInput = screen.getByTestId('login-password-input');
-    const signInButton = screen.getByTestId('login-signin-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
+    fillForm('test@example.com', 'password123');
+    const signInButton = await waitForButtonEnabled();
     fireEvent.press(signInButton);
 
-    // Button should be disabled during loading
     await waitFor(() => {
       expect(signInButton.props.accessibilityState?.disabled).toBe(true);
     });
   });
 
-  it('validates email format', async () => {
+  it('shows inline error for invalid email format', async () => {
     render(
       <AuthProvider>
         <LoginScreen />
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('login-email-input');
-    const passwordInput = screen.getByTestId('login-password-input');
-    const signInButton = screen.getByTestId('login-signin-button');
+    fillForm('invalid-email', 'password123');
 
-    // Test with invalid email format
-    fireEvent.changeText(emailInput, 'invalid-email');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.press(signInButton);
-
-    // Should still attempt sign in (validation happens on server)
     await waitFor(() => {
-      expect(mockSignIn).toHaveBeenCalledWith('invalid-email', 'password123');
+      expect(screen.getByTestId('login-email-error')).toBeTruthy();
     });
+    expect(mockSignIn).not.toHaveBeenCalled();
   });
-}); 
+});

--- a/__tests__/screens/PasswordResetConfirmScreen.test.tsx
+++ b/__tests__/screens/PasswordResetConfirmScreen.test.tsx
@@ -80,37 +80,31 @@ describe('PasswordResetConfirmScreen', () => {
       fireEvent.changeText(screen.getByTestId('password-reset-confirm-confirmation-input'), confirmation);
     };
 
-    it('shows a validation error when any field is empty', async () => {
+    it('keeps the submit button disabled when any field is empty', () => {
       renderScreen();
 
-      fireEvent.press(screen.getByTestId('password-reset-confirm-submit-button'));
-
-      await waitFor(() => {
-        expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
-      });
+      const button = screen.getByTestId('password-reset-confirm-submit-button');
+      expect(button.props.accessibilityState?.disabled).toBe(true);
+      fireEvent.press(button);
       expect(mockResetPassword).not.toHaveBeenCalled();
     });
 
-    it('shows a validation error when passwords do not match', async () => {
+    it('shows an inline error when passwords do not match', async () => {
       renderScreen();
       fillForm('code-abc', 'newpassword456', 'mismatch789');
 
-      fireEvent.press(screen.getByTestId('password-reset-confirm-submit-button'));
-
       await waitFor(() => {
-        expect(mockToastError).toHaveBeenCalledWith('Passwords do not match');
+        expect(screen.getByTestId('password-reset-confirm-confirmation-error')).toBeTruthy();
       });
       expect(mockResetPassword).not.toHaveBeenCalled();
     });
 
-    it('shows a validation error when the password is shorter than 6 characters', async () => {
+    it('shows an inline error when the password is shorter than 6 characters', async () => {
       renderScreen();
       fillForm('code-abc', 'short', 'short');
 
-      fireEvent.press(screen.getByTestId('password-reset-confirm-submit-button'));
-
       await waitFor(() => {
-        expect(mockToastError).toHaveBeenCalledWith('Password must be at least 6 characters long');
+        expect(screen.getByTestId('password-reset-confirm-password-error')).toBeTruthy();
       });
       expect(mockResetPassword).not.toHaveBeenCalled();
     });
@@ -120,7 +114,11 @@ describe('PasswordResetConfirmScreen', () => {
       renderScreen();
       fillForm('  code-abc  ', 'newpassword456', 'newpassword456');
 
-      fireEvent.press(screen.getByTestId('password-reset-confirm-submit-button'));
+      const button = screen.getByTestId('password-reset-confirm-submit-button');
+      await waitFor(() => {
+        expect(button.props.accessibilityState?.disabled).toBe(false);
+      });
+      fireEvent.press(button);
 
       await waitFor(() => {
         expect(mockResetPassword).toHaveBeenCalledWith('code-abc', 'newpassword456', 'newpassword456');
@@ -137,7 +135,11 @@ describe('PasswordResetConfirmScreen', () => {
       renderScreen();
       fillForm('code-abc', 'newpassword456', 'newpassword456');
 
-      fireEvent.press(screen.getByTestId('password-reset-confirm-submit-button'));
+      const button = screen.getByTestId('password-reset-confirm-submit-button');
+      await waitFor(() => {
+        expect(button.props.accessibilityState?.disabled).toBe(false);
+      });
+      fireEvent.press(button);
 
       await waitFor(() => {
         expect(mockToastError).toHaveBeenCalledWith('Reset password token has expired');

--- a/__tests__/screens/SignupScreen.test.tsx
+++ b/__tests__/screens/SignupScreen.test.tsx
@@ -42,6 +42,20 @@ jest.mock('../../hooks/useAuth', () => ({
   AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const fillForm = (email: string, password: string, confirmation: string) => {
+  fireEvent.changeText(screen.getByTestId('signup-email-input'), email);
+  fireEvent.changeText(screen.getByTestId('signup-password-input'), password);
+  fireEvent.changeText(screen.getByTestId('signup-password-confirmation-input'), confirmation);
+};
+
+const waitForButtonEnabled = async () => {
+  const button = screen.getByTestId('signup-signup-button');
+  await waitFor(() => {
+    expect(button.props.accessibilityState?.disabled).toBe(false);
+  });
+  return button;
+};
+
 describe('SignupScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -63,7 +77,7 @@ describe('SignupScreen', () => {
     expect(screen.getByTestId('signup-signin-link')).toBeTruthy();
   });
 
-  it('shows validation error when fields are empty', async () => {
+  it('keeps the submit button disabled while fields are empty', () => {
     render(
       <AuthProvider>
         <SignupScreen />
@@ -71,55 +85,39 @@ describe('SignupScreen', () => {
     );
 
     const signupButton = screen.getByTestId('signup-signup-button');
+    expect(signupButton.props.accessibilityState?.disabled).toBe(true);
     fireEvent.press(signupButton);
-
-    await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
-    });
+    expect(mockSignUp).not.toHaveBeenCalled();
   });
 
-  it('shows validation error when passwords do not match', async () => {
+  it('shows inline error when passwords do not match', async () => {
     render(
       <AuthProvider>
         <SignupScreen />
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.changeText(passwordConfirmationInput, 'differentpassword');
-    fireEvent.press(signupButton);
+    fillForm('test@example.com', 'password123', 'differentpassword');
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Passwords do not match');
+      expect(screen.getByTestId('signup-password-confirmation-error')).toBeTruthy();
     });
+    expect(mockSignUp).not.toHaveBeenCalled();
   });
 
-  it('shows validation error when password is too short', async () => {
+  it('shows inline error when password is too short', async () => {
     render(
       <AuthProvider>
         <SignupScreen />
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, '123');
-    fireEvent.changeText(passwordConfirmationInput, '123');
-    fireEvent.press(signupButton);
+    fillForm('test@example.com', '123', '123');
 
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Password must be at least 6 characters long');
+      expect(screen.getByTestId('signup-password-error')).toBeTruthy();
     });
+    expect(mockSignUp).not.toHaveBeenCalled();
   });
 
   it('handles successful sign up', async () => {
@@ -131,14 +129,8 @@ describe('SignupScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.changeText(passwordConfirmationInput, 'password123');
+    fillForm('test@example.com', 'password123', 'password123');
+    const signupButton = await waitForButtonEnabled();
     fireEvent.press(signupButton);
 
     await waitFor(() => {
@@ -156,14 +148,8 @@ describe('SignupScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
-
-    fireEvent.changeText(emailInput, 'existing@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.changeText(passwordConfirmationInput, 'password123');
+    fillForm('existing@example.com', 'password123', 'password123');
+    const signupButton = await waitForButtonEnabled();
     fireEvent.press(signupButton);
 
     await waitFor(() => {
@@ -195,17 +181,10 @@ describe('SignupScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.changeText(passwordConfirmationInput, 'password123');
+    fillForm('test@example.com', 'password123', 'password123');
+    const signupButton = await waitForButtonEnabled();
     fireEvent.press(signupButton);
 
-    // Check that loading indicator appears
     await waitFor(() => {
       expect(screen.getByTestId('signup-loading-indicator')).toBeTruthy();
     });
@@ -220,64 +199,46 @@ describe('SignupScreen', () => {
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
-
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.changeText(passwordConfirmationInput, 'password123');
+    fillForm('test@example.com', 'password123', 'password123');
+    const signupButton = await waitForButtonEnabled();
     fireEvent.press(signupButton);
 
-    // Button should be disabled during loading
     await waitFor(() => {
       expect(signupButton.props.accessibilityState?.disabled).toBe(true);
     });
   });
 
-  it('validates email format', async () => {
+  it('shows inline error for invalid email format', async () => {
     render(
       <AuthProvider>
         <SignupScreen />
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
-    const passwordConfirmationInput = screen.getByTestId('signup-password-confirmation-input');
-    const signupButton = screen.getByTestId('signup-signup-button');
+    fillForm('invalid-email', 'password123', 'password123');
 
-    // Test with invalid email format
-    fireEvent.changeText(emailInput, 'invalid-email');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.changeText(passwordConfirmationInput, 'password123');
-    fireEvent.press(signupButton);
-
-    // Should still attempt sign up (validation happens on server)
     await waitFor(() => {
-      expect(mockSignUp).toHaveBeenCalledWith('invalid-email', 'password123', 'password123');
+      expect(screen.getByTestId('signup-email-error')).toBeTruthy();
     });
+    expect(mockSignUp).not.toHaveBeenCalled();
   });
 
-  it('handles partial field validation', async () => {
+  it('keeps the submit button disabled when only some fields are filled', async () => {
     render(
       <AuthProvider>
         <SignupScreen />
       </AuthProvider>
     );
 
-    const emailInput = screen.getByTestId('signup-email-input');
-    const passwordInput = screen.getByTestId('signup-password-input');
     const signupButton = screen.getByTestId('signup-signup-button');
 
-    // Fill only email and password, leave confirmation empty
-    fireEvent.changeText(emailInput, 'test@example.com');
-    fireEvent.changeText(passwordInput, 'password123');
-    fireEvent.press(signupButton);
+    fireEvent.changeText(screen.getByTestId('signup-email-input'), 'test@example.com');
+    fireEvent.changeText(screen.getByTestId('signup-password-input'), 'password123');
 
+    // confirmation left empty
     await waitFor(() => {
-      expect(mockToastError).toHaveBeenCalledWith('Please fill in all fields');
+      expect(signupButton.props.accessibilityState?.disabled).toBe(true);
     });
+    expect(mockSignUp).not.toHaveBeenCalled();
   });
 });

--- a/__tests__/screens/TodaysFocusScreen.test.tsx
+++ b/__tests__/screens/TodaysFocusScreen.test.tsx
@@ -194,6 +194,19 @@ describe('TodaysFocusScreen', () => {
     expect(screen.getByTestId("todays-focus-title")).toBeTruthy();
   });
 
+  it('shows profile loading fallback when auth profile is temporarily unavailable', () => {
+    mockUseAuth.mockReturnValue({
+      user: { id: 1, email: 'test@example.com' },
+      profile: null,
+      isLoading: false,
+    });
+
+    renderTodaysFocusScreen();
+
+    expect(screen.getByTestId('todays-focus-profile-loading')).toBeTruthy();
+    expect(screen.queryByTestId('todays-focus-title')).toBeNull();
+  });
+
   it('renders the assist me button', () => {
     renderTodaysFocusScreen();
 

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -1,3 +1,4 @@
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import TabBarBackground from '@/components/ui/TabBarBackground';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -30,41 +31,43 @@ export default function TabLayout() {
   }, [profile, isLoading]);
 
   return (
-    <Tabs
-      screenOptions={{
-        tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
-        tabBarBackground: TabBarBackground,
-        tabBarStyle: Platform.select({
-          ios: {
-            position: 'absolute',
-          },
-          default: {},
-        }),
-      }}>
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: 'Tasks',
-          headerShown: false,
-          tabBarIcon: ({ color }) => <FontAwesome5 name="tasks" size={24} color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="todaysFocus"
-        options={{
-          headerShown: false,
-          title: "Today's Focus",
-          tabBarIcon: ({ color }) => <Ionicons name="compass" size={28} color={color} />,
-        }}
-      />
-      <Tabs.Screen
-        name="menu"
-        options={{
-          title: 'Menu',
-          headerShown: false,
-          tabBarIcon: ({ color }) => <Ionicons name="menu" size={28} color={color} />,
-        }}
-      />
-    </Tabs>
+    <ErrorBoundary scope="tabs">
+      <Tabs
+        screenOptions={{
+          tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
+          tabBarBackground: TabBarBackground,
+          tabBarStyle: Platform.select({
+            ios: {
+              position: 'absolute',
+            },
+            default: {},
+          }),
+        }}>
+        <Tabs.Screen
+          name="index"
+          options={{
+            title: 'Tasks',
+            headerShown: false,
+            tabBarIcon: ({ color }) => <FontAwesome5 name="tasks" size={24} color={color} />,
+          }}
+        />
+        <Tabs.Screen
+          name="todaysFocus"
+          options={{
+            headerShown: false,
+            title: "Today's Focus",
+            tabBarIcon: ({ color }) => <Ionicons name="compass" size={28} color={color} />,
+          }}
+        />
+        <Tabs.Screen
+          name="menu"
+          options={{
+            title: 'Menu',
+            headerShown: false,
+            tabBarIcon: ({ color }) => <Ionicons name="menu" size={28} color={color} />,
+          }}
+        />
+      </Tabs>
+    </ErrorBoundary>
   );
 }

--- a/app/(tabs)/todaysFocus.tsx
+++ b/app/(tabs)/todaysFocus.tsx
@@ -26,9 +26,20 @@ export default function TodaysFocusScreen() {
   const [isFocusMode, setIsFocusMode] = useState(false);
   const [loadingSuggestions, setLoadingSuggestions] = useState<Set<string>>(new Set());
 
-  // Profile should always exist at this point due to auth protection in _layout.tsx
+  // During auth/profile hydration, profile can be temporarily unavailable.
   if (!profile) {
-    throw new Error('Profile is required but not available. This should not happen.');
+    return (
+      <LinearGradient>
+        <View className="flex-1 items-center justify-center px-5">
+          <LoadingSpinner
+            size="medium"
+            text="Loading your profile..."
+            variant="inline"
+            testID="todays-focus-profile-loading"
+          />
+        </View>
+      </LinearGradient>
+    );
   }
 
   const {

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -29,12 +29,12 @@ function AppContent() {
     SpaceMono: require('../assets/fonts/SpaceMono-Regular.ttf'),
   });
   const [showSplash, setShowSplash] = useState(true);
-  const { user, isLoading } = useAuth();
+  const { user, profile, isLoading } = useAuth();
 
   // Navigation logic - redirect based on authentication state
   useEffect(() => {
     if (!isLoading && !showSplash) {
-      if (user) {
+      if (user && profile) {
         // User is authenticated, redirect to main app
         router.replace('/(tabs)');
       } else {
@@ -42,7 +42,7 @@ function AppContent() {
         router.replace('/auth/login');
       }
     }
-  }, [user, isLoading, showSplash]);
+  }, [user, profile, isLoading, showSplash]);
 
   if (!loaded) {
     return null;

--- a/app/addGoal/index.tsx
+++ b/app/addGoal/index.tsx
@@ -1,8 +1,12 @@
 import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Ionicons } from '@expo/vector-icons';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAvoidingView, Platform, Text, View } from 'react-native';
+import { z } from 'zod';
 import { GoalDescriptionInput } from '../../components/goals/GoalDescriptionInput';
 import { GoalPreviewCard } from '../../components/goals/GoalPreviewCard';
 import { TimeframeSelector } from '../../components/goals/TimeframeSelector';
@@ -12,20 +16,57 @@ import ScrollView from '../../components/util/ScrollView';
 import { useGoalCreation } from '../../hooks/useGoalCreation';
 import { TIMEFRAME_OPTIONS, formatTimeframeForAiResponse } from '../../utils/smartGoalFormatters';
 
+const TIMEFRAME_VALUES = ['1 month', '3 months', '6 months'] as const;
+
+const addGoalFormSchema = z.object({
+  goalDescription: z
+    .string()
+    .trim()
+    .min(10, 'Please describe your goal in at least 10 characters')
+    .max(2000, 'Goal description is too long'),
+  selectedTimeframe: z.enum(TIMEFRAME_VALUES, { message: 'Please select a timeframe' }),
+});
+
+type AddGoalFormValues = z.infer<typeof addGoalFormSchema>;
+
+const fieldErrorClassName = 'text-red-400 text-xs mt-2';
+
 export default function AddGoalScreen() {
+  return (
+    <ErrorBoundary scope="add-goal">
+      <AddGoalContent />
+    </ErrorBoundary>
+  );
+}
+
+function AddGoalContent() {
   const {
-    goalDescription,
-    selectedTimeframe,
-    setGoalDescription,
-    setSelectedTimeframe,
     handleCreateGoal,
     handleConfirmGoal,
     handleEditGoal,
     handleCancel,
     isLoading,
     aiResponse,
-    showConfirmation
+    showConfirmation,
   } = useGoalCreation();
+
+  const { control, handleSubmit, getValues, formState: { errors, isValid } } = useForm<AddGoalFormValues>({
+    resolver: zodResolver(addGoalFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      goalDescription: '',
+      selectedTimeframe: undefined,
+    },
+  });
+
+  const onCreate = (values: AddGoalFormValues) =>
+    handleCreateGoal(values.goalDescription, values.selectedTimeframe);
+
+  const onConfirm = () => {
+    const { goalDescription, selectedTimeframe } = getValues();
+    if (!selectedTimeframe) return;
+    return handleConfirmGoal(goalDescription, selectedTimeframe);
+  };
 
   if (isLoading) {
     return (
@@ -39,6 +80,7 @@ export default function AddGoalScreen() {
   }
 
   if (!isLoading && aiResponse && showConfirmation) {
+    const selectedTimeframe = getValues('selectedTimeframe');
     return (
       <LinearGradient>
         <ScrollView
@@ -49,23 +91,22 @@ export default function AddGoalScreen() {
             paddingBottom: 40
           }}
         >
-          {/* Header */}
           <View className="flex-row items-center mb-8">
             <Text className="text-2xl font-semibold text-[#F1F5F9]">
               Confirm Your Goal
             </Text>
           </View>
 
-          {/* Goal Preview Card */}
-          <GoalPreviewCard
-            goalData={formatTimeframeForAiResponse(selectedTimeframe, aiResponse)}
-            testID="add-goal-preview-card"
-          />
+          {selectedTimeframe && (
+            <GoalPreviewCard
+              goalData={formatTimeframeForAiResponse(selectedTimeframe, aiResponse)}
+              testID="add-goal-preview-card"
+            />
+          )}
 
-          {/* Action Buttons */}
           <View className="gap-4 mb-8">
             <PrimaryButton
-              onPress={handleConfirmGoal}
+              onPress={onConfirm}
               title="Confirm & Save Goal"
               testID="confirm-goal-button"
             />
@@ -122,26 +163,46 @@ export default function AddGoalScreen() {
             </View>
           </View>
 
-          {/* Goal Description Input */}
-          <GoalDescriptionInput
-            value={goalDescription}
-            onChangeText={setGoalDescription}
-            testID="add-goal-description-input"
+          <Controller
+            control={control}
+            name="goalDescription"
+            render={({ field: { value, onChange } }) => (
+              <GoalDescriptionInput
+                value={value}
+                onChangeText={onChange}
+                testID="add-goal-description-input"
+              />
+            )}
           />
+          {errors.goalDescription && (
+            <Text className={fieldErrorClassName} testID="add-goal-description-error">
+              {errors.goalDescription.message}
+            </Text>
+          )}
 
-          {/* Timeframe Selection */}
-          <TimeframeSelector
-            options={TIMEFRAME_OPTIONS}
-            selectedTimeframe={selectedTimeframe}
-            onTimeframeSelect={setSelectedTimeframe}
-            testID="add-goal-timeframe-selector"
+          <Controller
+            control={control}
+            name="selectedTimeframe"
+            render={({ field: { value, onChange } }) => (
+              <TimeframeSelector
+                options={TIMEFRAME_OPTIONS}
+                selectedTimeframe={value ?? ''}
+                onTimeframeSelect={onChange}
+                testID="add-goal-timeframe-selector"
+              />
+            )}
           />
+          {errors.selectedTimeframe && (
+            <Text className={fieldErrorClassName} testID="add-goal-timeframe-error">
+              {errors.selectedTimeframe.message}
+            </Text>
+          )}
 
           <View className="gap-4">
             <PrimaryButton
-              onPress={handleCreateGoal}
+              onPress={handleSubmit(onCreate)}
               title={isLoading ? 'Creating Goal...' : 'Create SMART Goal'}
-              disabled={isLoading || !goalDescription.trim() || !selectedTimeframe}
+              disabled={!isValid || isLoading}
               testID="add-goal-create-goal-button"
             />
             <SecondaryButton

--- a/app/addTask/index.tsx
+++ b/app/addTask/index.tsx
@@ -1,48 +1,63 @@
 import { CreateTaskParams } from '@/api/tasks';
 import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { PriorityInput } from '@/components/inputs';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useCreateTask } from '@/hooks/useTasks';
+import { taskSchema } from '@/models';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
-import React, { useState } from 'react';
+import React from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
+import { z } from 'zod';
+
+const addTaskFormSchema = taskSchema.pick({
+  title: true,
+  description: true,
+  priority: true,
+  action_category: true,
+});
+
+type AddTaskFormValues = z.infer<typeof addTaskFormSchema>;
+
+const fieldErrorClassName = 'text-red-400 text-xs mt-1';
 
 export default function AddTaskScreen() {
-  const [taskDetails, setTaskDetails] = useState({
-    name: '',
-    description: '',
-    priority: 1,
-    action_category: 'do' as 'do' | 'defer' | 'delegate'
-  });
+  return (
+    <ErrorBoundary scope="add-task">
+      <AddTaskContent />
+    </ErrorBoundary>
+  );
+}
 
+function AddTaskContent() {
   const createTaskMutation = useCreateTask();
 
-  const handleAdd = () => {
-    if (taskDetails.name.trim()) {
-      const newTask: CreateTaskParams = {
-        title: taskDetails.name.trim(),
-        description: taskDetails.description.trim() || undefined,
-        priority: taskDetails.priority,
-        action_category: taskDetails.action_category,
-        completed: false,
-      };
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<AddTaskFormValues>({
+    resolver: zodResolver(addTaskFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      title: '',
+      description: '',
+      priority: 1,
+      action_category: 'do',
+    },
+  });
 
-      createTaskMutation.mutate(newTask, {
-        onSuccess: () => {
-          // Navigate back to home screen
-          router.push('/(tabs)');
-        },
-      });
-    }
-  };
+  const onSubmit = (values: AddTaskFormValues) => {
+    const newTask: CreateTaskParams = {
+      title: values.title,
+      description: values.description || undefined,
+      priority: values.priority,
+      action_category: values.action_category,
+      completed: false,
+    };
 
-  const handleCategoryChange = (category: 'do' | 'defer' | 'delegate') => {
-    setTaskDetails(prev => ({ ...prev, action_category: category }));
-  };
-
-  const handlePriorityChange = (priority: number) => {
-    setTaskDetails(prev => ({ ...prev, priority: priority }));
+    createTaskMutation.mutate(newTask, {
+      onSuccess: () => router.push('/(tabs)'),
+    });
   };
 
   return (
@@ -62,66 +77,106 @@ export default function AddTaskScreen() {
           <View className="gap-4">
             <Text className="mt-8 mb-5 font-semibold text-center text-3xl text-[#F1F5F9]">What do you need to get done?</Text>
 
-            <TextInput
-              className="bg-[#2B42B6] rounded-2xl p-4 text-[#F1F5F9] text-base border border-[#274B8E]"
-              placeholder="Name"
-              placeholderTextColor="#708090"
-              value={taskDetails.name}
-              onChangeText={(e) => setTaskDetails(prev => ({ ...prev, name: e }))}
-              autoFocus
-              editable={!createTaskMutation.isPending}
-              testID="add-task-task-name-input"
-            />
+            <View>
+              <Controller
+                control={control}
+                name="title"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className="bg-[#2B42B6] rounded-2xl p-4 text-[#F1F5F9] text-base border border-[#274B8E]"
+                    placeholder="Name"
+                    placeholderTextColor="#708090"
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    autoFocus
+                    editable={!createTaskMutation.isPending}
+                    testID="add-task-task-name-input"
+                  />
+                )}
+              />
+              {errors.title && (
+                <Text className={fieldErrorClassName} testID="add-task-task-name-error">
+                  {errors.title.message}
+                </Text>
+              )}
+            </View>
 
-            <TextInput
-              className="bg-[#2B42B6] rounded-2xl p-4 text-[#F1F5F9] text-base border border-[#274B8E]"
-              placeholder="Description (optional)"
-              placeholderTextColor="#708090"
-              value={taskDetails.description}
-              onChangeText={(e) => setTaskDetails(prev => ({ ...prev, description: e }))}
-              multiline
-              editable={!createTaskMutation.isPending}
-              testID="add-task-task-description-input"
-            />
+            <View>
+              <Controller
+                control={control}
+                name="description"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className="bg-[#2B42B6] rounded-2xl p-4 text-[#F1F5F9] text-base border border-[#274B8E]"
+                    placeholder="Description (optional)"
+                    placeholderTextColor="#708090"
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    multiline
+                    editable={!createTaskMutation.isPending}
+                    testID="add-task-task-description-input"
+                  />
+                )}
+              />
+              {errors.description && (
+                <Text className={fieldErrorClassName}>
+                  {errors.description.message}
+                </Text>
+              )}
+            </View>
 
-            <PriorityInput
-              value={taskDetails.priority}
-              onChange={handlePriorityChange}
-              disabled={createTaskMutation.isPending}
-              showLabel
+            <Controller
+              control={control}
+              name="priority"
+              render={({ field: { value, onChange } }) => (
+                <PriorityInput
+                  value={value ?? 1}
+                  onChange={onChange}
+                  disabled={createTaskMutation.isPending}
+                  showLabel
+                />
+              )}
             />
 
             <View className="mb-5">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Action Category:</Text>
-              <View className="flex-row gap-2">
-                {(['do', 'defer', 'delegate'] as const).map((category) => (
-                  <Pressable
-                    key={category}
-                    onPress={() => handleCategoryChange(category)}
-                    className={`flex-1 py-2 px-3 rounded-lg border ${taskDetails.action_category === category
-                      ? 'border-cyan-400 bg-cyan-400'
-                      : 'border-[#708090] bg-[#13203a]'
-                      }`}
-                    disabled={createTaskMutation.isPending}
-                  >
-                    <Text
-                      className={`text-center font-medium capitalize ${taskDetails.action_category === category
-                        ? 'text-[#021A40]'
-                        : 'text-[#E6FAFF]'
-                        }`}
-                    >
-                      {category}
-                    </Text>
-                  </Pressable>
-                ))}
-              </View>
+              <Controller
+                control={control}
+                name="action_category"
+                render={({ field: { value, onChange } }) => (
+                  <View className="flex-row gap-2">
+                    {(['do', 'defer', 'delegate'] as const).map((category) => (
+                      <Pressable
+                        key={category}
+                        onPress={() => onChange(category)}
+                        className={`flex-1 py-2 px-3 rounded-lg border ${value === category
+                          ? 'border-cyan-400 bg-cyan-400'
+                          : 'border-[#708090] bg-[#13203a]'
+                          }`}
+                        disabled={createTaskMutation.isPending}
+                      >
+                        <Text
+                          className={`text-center font-medium capitalize ${value === category
+                            ? 'text-[#021A40]'
+                            : 'text-[#E6FAFF]'
+                            }`}
+                        >
+                          {category}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                )}
+              />
             </View>
 
             <View className="gap-4">
               <PrimaryButton
                 title='Add'
-                onPress={handleAdd}
-                disabled={!taskDetails.name.trim() || createTaskMutation.isPending}
+                onPress={handleSubmit(onSubmit)}
+                disabled={!isValid || createTaskMutation.isPending}
                 isLoading={createTaskMutation.isPending}
                 loadingText='Adding...'
                 testID='add-task-add-button'

--- a/app/auth/forgot-password.tsx
+++ b/app/auth/forgot-password.tsx
@@ -2,8 +2,11 @@ import LinearGradient from '@/components/ui/LinearGradient';
 import { useToast } from '@/components/ToastManager';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
+import { emailSchema } from '@/models';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -13,19 +16,28 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { z } from 'zod';
+
+const forgotPasswordFormSchema = z.object({
+  email: emailSchema,
+});
+
+type ForgotPasswordFormValues = z.infer<typeof forgotPasswordFormSchema>;
+
+const fieldErrorClassName = 'mt-1 text-xs text-red-400';
 
 export default function ForgotPasswordScreen() {
-  const [email, setEmail] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { requestPasswordReset } = useAuth();
   const toast = useToast();
 
-  const handleSubmit = async () => {
-    if (!email) {
-      toast.error('Please enter your email');
-      return;
-    }
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<ForgotPasswordFormValues>({
+    resolver: zodResolver(forgotPasswordFormSchema),
+    mode: 'onChange',
+    defaultValues: { email: '' },
+  });
 
+  const onSubmit = async ({ email }: ForgotPasswordFormValues) => {
     setIsLoading(true);
     try {
       await requestPasswordReset(email);
@@ -41,9 +53,7 @@ export default function ForgotPasswordScreen() {
     }
   };
 
-  const handleBackToLogin = () => {
-    router.replace('/auth/login');
-  };
+  const handleBackToLogin = () => router.replace('/auth/login');
 
   return (
     <LinearGradient>
@@ -73,29 +83,41 @@ export default function ForgotPasswordScreen() {
               <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                 Email
               </Text>
-              <TextInput
-                testID="forgot-password-email-input"
-                className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                placeholder="Enter your email"
-                value={email}
-                onChangeText={setEmail}
-                keyboardType="email-address"
-                autoCapitalize="none"
-                autoCorrect={false}
-                style={{
-                  shadowColor: '#274B8E',
-                  shadowOpacity: 0.10,
-                  shadowRadius: 10,
-                  shadowOffset: { width: 0, height: 3 }
-                }}
+              <Controller
+                control={control}
+                name="email"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    testID="forgot-password-email-input"
+                    className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                    placeholder="Enter your email"
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    keyboardType="email-address"
+                    autoCapitalize="none"
+                    autoCorrect={false}
+                    style={{
+                      shadowColor: '#274B8E',
+                      shadowOpacity: 0.10,
+                      shadowRadius: 10,
+                      shadowOffset: { width: 0, height: 3 }
+                    }}
+                  />
+                )}
               />
+              {errors.email && (
+                <Text className={fieldErrorClassName} testID="forgot-password-email-error">
+                  {errors.email.message}
+                </Text>
+              )}
             </View>
 
             <TouchableOpacity
               testID="forgot-password-submit-button"
-              className={`w-full py-4 rounded-xl shadow-md mb-8 ${isLoading ? 'bg-[#808080]' : 'bg-cyan-400'}`}
-              onPress={handleSubmit}
-              disabled={isLoading}
+              className={`w-full py-4 rounded-xl shadow-md mb-8 ${isLoading || !isValid ? 'bg-[#808080]' : 'bg-cyan-400'}`}
+              onPress={handleSubmit(onSubmit)}
+              disabled={isLoading || !isValid}
               style={{
                 shadowColor: isLoading ? '#808080' : '#33CFFF',
                 shadowOpacity: isLoading ? 0.12 : 0.25,

--- a/app/auth/login.tsx
+++ b/app/auth/login.tsx
@@ -2,8 +2,11 @@ import LinearGradient from '@/components/ui/LinearGradient';
 import { useToast } from '@/components/ToastManager';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
+import { emailSchema, passwordSchema } from '@/models';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -13,23 +16,32 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { z } from 'zod';
+
+const loginFormSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+});
+
+type LoginFormValues = z.infer<typeof loginFormSchema>;
+
+const fieldErrorClassName = 'mt-1 text-xs text-red-400';
 
 export default function LoginScreen() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { signIn } = useAuth();
   const toast = useToast();
 
-  const handleSignIn = async () => {
-    if (!email || !password) {
-      toast.error('Please fill in all fields');
-      return;
-    }
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<LoginFormValues>({
+    resolver: zodResolver(loginFormSchema),
+    mode: 'onChange',
+    defaultValues: { email: '', password: '' },
+  });
 
+  const onSubmit = async (values: LoginFormValues) => {
     setIsLoading(true);
     try {
-      await signIn(email, password);
+      await signIn(values.email, values.password);
       router.replace('/(tabs)');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Sign in failed');
@@ -38,13 +50,8 @@ export default function LoginScreen() {
     }
   };
 
-  const handleSignUp = () => {
-    router.push('/auth/signup');
-  };
-
-  const handleForgotPassword = () => {
-    router.push('/auth/forgot-password');
-  };
+  const handleSignUp = () => router.push('/auth/signup');
+  const handleForgotPassword = () => router.push('/auth/forgot-password');
 
   return (
     <LinearGradient>
@@ -75,44 +82,68 @@ export default function LoginScreen() {
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Email
                 </Text>
-                <TextInput
-                  testID="login-email-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Enter your email"
-                  value={email}
-                  onChangeText={setEmail}
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="email"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="login-email-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Enter your email"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      keyboardType="email-address"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.email && (
+                  <Text className={fieldErrorClassName} testID="login-email-error">
+                    {errors.email.message}
+                  </Text>
+                )}
               </View>
 
               <View>
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Password
                 </Text>
-                <TextInput
-                  testID="login-password-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Enter your password"
-                  value={password}
-                  onChangeText={setPassword}
-                  secureTextEntry
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="password"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="login-password-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Enter your password"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      secureTextEntry
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.password && (
+                  <Text className={fieldErrorClassName} testID="login-password-error">
+                    {errors.password.message}
+                  </Text>
+                )}
               </View>
 
               <View className="items-end mt-3">
@@ -124,9 +155,9 @@ export default function LoginScreen() {
 
             <TouchableOpacity
               testID="login-signin-button"
-              className={`w-full py-4 rounded-xl shadow-md mb-8 ${isLoading ? 'bg-[#808080]' : 'bg-cyan-400'}`}
-              onPress={handleSignIn}
-              disabled={isLoading}
+              className={`w-full py-4 rounded-xl shadow-md mb-8 ${isLoading || !isValid ? 'bg-[#808080]' : 'bg-cyan-400'}`}
+              onPress={handleSubmit(onSubmit)}
+              disabled={isLoading || !isValid}
               style={{
                 shadowColor: isLoading ? '#808080' : '#33CFFF',
                 shadowOpacity: isLoading ? 0.12 : 0.25,

--- a/app/auth/password-reset-confirm.tsx
+++ b/app/auth/password-reset-confirm.tsx
@@ -2,8 +2,11 @@ import LinearGradient from '@/components/ui/LinearGradient';
 import { useToast } from '@/components/ToastManager';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
+import { passwordSchema } from '@/models';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router, useLocalSearchParams } from 'expo-router';
 import React, { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -13,38 +16,42 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { z } from 'zod';
+
+const passwordResetConfirmSchema = z
+  .object({
+    code: z.string().trim().min(1, 'Reset code is required'),
+    password: passwordSchema,
+    passwordConfirmation: z.string(),
+  })
+  .refine((values) => values.password === values.passwordConfirmation, {
+    message: 'Passwords do not match',
+    path: ['passwordConfirmation'],
+  });
+
+type PasswordResetConfirmFormValues = z.infer<typeof passwordResetConfirmSchema>;
+
+const fieldErrorClassName = 'mt-1 text-xs text-red-400';
 
 export default function PasswordResetConfirmScreen() {
   const params = useLocalSearchParams<{ email?: string }>();
   const email = typeof params.email === 'string' ? params.email : '';
 
-  const [code, setCode] = useState('');
-  const [password, setPassword] = useState('');
-  const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const [isResending, setIsResending] = useState(false);
   const { resetPassword, requestPasswordReset } = useAuth();
   const toast = useToast();
 
-  const handleSubmit = async () => {
-    if (!code || !password || !passwordConfirmation) {
-      toast.error('Please fill in all fields');
-      return;
-    }
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<PasswordResetConfirmFormValues>({
+    resolver: zodResolver(passwordResetConfirmSchema),
+    mode: 'onChange',
+    defaultValues: { code: '', password: '', passwordConfirmation: '' },
+  });
 
-    if (password !== passwordConfirmation) {
-      toast.error('Passwords do not match');
-      return;
-    }
-
-    if (password.length < 6) {
-      toast.error('Password must be at least 6 characters long');
-      return;
-    }
-
+  const onSubmit = async (values: PasswordResetConfirmFormValues) => {
     setIsLoading(true);
     try {
-      await resetPassword(code.trim(), password, passwordConfirmation);
+      await resetPassword(values.code.trim(), values.password, values.passwordConfirmation);
       toast.success('Password reset successfully. Please sign in.');
       router.replace('/auth/login');
     } catch (error) {
@@ -72,9 +79,7 @@ export default function PasswordResetConfirmScreen() {
     }
   };
 
-  const handleBackToLogin = () => {
-    router.replace('/auth/login');
-  };
+  const handleBackToLogin = () => router.replace('/auth/login');
 
   return (
     <LinearGradient>
@@ -107,73 +112,109 @@ export default function PasswordResetConfirmScreen() {
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Reset Code
                 </Text>
-                <TextInput
-                  testID="password-reset-confirm-code-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Paste the code from your email"
-                  value={code}
-                  onChangeText={setCode}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="code"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="password-reset-confirm-code-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Paste the code from your email"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.code && (
+                  <Text className={fieldErrorClassName} testID="password-reset-confirm-code-error">
+                    {errors.code.message}
+                  </Text>
+                )}
               </View>
 
               <View className="mb-4">
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   New Password
                 </Text>
-                <TextInput
-                  testID="password-reset-confirm-password-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Enter new password"
-                  value={password}
-                  onChangeText={setPassword}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  secureTextEntry
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="password"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="password-reset-confirm-password-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Enter new password"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      secureTextEntry
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.password && (
+                  <Text className={fieldErrorClassName} testID="password-reset-confirm-password-error">
+                    {errors.password.message}
+                  </Text>
+                )}
               </View>
 
               <View>
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Confirm Password
                 </Text>
-                <TextInput
-                  testID="password-reset-confirm-confirmation-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Confirm new password"
-                  value={passwordConfirmation}
-                  onChangeText={setPasswordConfirmation}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  secureTextEntry
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="passwordConfirmation"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="password-reset-confirm-confirmation-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Confirm new password"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      secureTextEntry
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.passwordConfirmation && (
+                  <Text className={fieldErrorClassName} testID="password-reset-confirm-confirmation-error">
+                    {errors.passwordConfirmation.message}
+                  </Text>
+                )}
               </View>
             </View>
 
             <TouchableOpacity
               testID="password-reset-confirm-submit-button"
-              className={`w-full py-4 rounded-xl shadow-md mb-6 ${isLoading ? 'bg-[#808080]' : 'bg-cyan-400'}`}
-              onPress={handleSubmit}
-              disabled={isLoading}
+              className={`w-full py-4 rounded-xl shadow-md mb-6 ${isLoading || !isValid ? 'bg-[#808080]' : 'bg-cyan-400'}`}
+              onPress={handleSubmit(onSubmit)}
+              disabled={isLoading || !isValid}
               style={{
                 shadowColor: isLoading ? '#808080' : '#33CFFF',
                 shadowOpacity: isLoading ? 0.12 : 0.25,

--- a/app/auth/signup.tsx
+++ b/app/auth/signup.tsx
@@ -2,8 +2,11 @@ import LinearGradient from '@/components/ui/LinearGradient';
 import { useToast } from '@/components/ToastManager';
 import ScrollView from '@/components/util/ScrollView';
 import { useAuth } from '@/hooks/useAuth';
+import { emailSchema, passwordSchema } from '@/models';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import {
   ActivityIndicator,
   KeyboardAvoidingView,
@@ -13,34 +16,38 @@ import {
   TouchableOpacity,
   View,
 } from 'react-native';
+import { z } from 'zod';
+
+const signupFormSchema = z
+  .object({
+    email: emailSchema,
+    password: passwordSchema,
+    passwordConfirmation: z.string(),
+  })
+  .refine((values) => values.password === values.passwordConfirmation, {
+    message: 'Passwords do not match',
+    path: ['passwordConfirmation'],
+  });
+
+type SignupFormValues = z.infer<typeof signupFormSchema>;
+
+const fieldErrorClassName = 'mt-1 text-xs text-red-400';
 
 export default function SignupScreen() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [passwordConfirmation, setPasswordConfirmation] = useState('');
   const [isLoading, setIsLoading] = useState(false);
   const { signUp } = useAuth();
   const toast = useToast();
 
-  const handleSignUp = async () => {
-    if (!email || !password || !passwordConfirmation) {
-      toast.error('Please fill in all fields');
-      return;
-    }
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<SignupFormValues>({
+    resolver: zodResolver(signupFormSchema),
+    mode: 'onChange',
+    defaultValues: { email: '', password: '', passwordConfirmation: '' },
+  });
 
-    if (password !== passwordConfirmation) {
-      toast.error('Passwords do not match');
-      return;
-    }
-
-    if (password.length < 6) {
-      toast.error('Password must be at least 6 characters long');
-      return;
-    }
-
+  const onSubmit = async (values: SignupFormValues) => {
     setIsLoading(true);
     try {
-      await signUp(email, password, passwordConfirmation);
+      await signUp(values.email, values.password, values.passwordConfirmation);
       router.replace('/(tabs)');
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Sign up failed');
@@ -49,9 +56,7 @@ export default function SignupScreen() {
     }
   };
 
-  const handleSignIn = () => {
-    router.push('/auth/login');
-  };
+  const handleSignIn = () => router.push('/auth/login');
 
   return (
     <LinearGradient>
@@ -82,74 +87,110 @@ export default function SignupScreen() {
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Email
                 </Text>
-                <TextInput
-                  testID="signup-email-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Enter your email"
-                  value={email}
-                  onChangeText={setEmail}
-                  keyboardType="email-address"
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="email"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="signup-email-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Enter your email"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      keyboardType="email-address"
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.email && (
+                  <Text className={fieldErrorClassName} testID="signup-email-error">
+                    {errors.email.message}
+                  </Text>
+                )}
               </View>
 
               <View className="mb-4">
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Password
                 </Text>
-                <TextInput
-                  testID="signup-password-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Enter your password"
-                  value={password}
-                  onChangeText={setPassword}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  secureTextEntry
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="password"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="signup-password-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Enter your password"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      secureTextEntry
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.password && (
+                  <Text className={fieldErrorClassName} testID="signup-password-error">
+                    {errors.password.message}
+                  </Text>
+                )}
               </View>
 
               <View>
                 <Text className="mb-2 text-sm font-medium text-[#E6FAFF]">
                   Confirm Password
                 </Text>
-                <TextInput
-                  testID="signup-password-confirmation-input"
-                  className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
-                  placeholder="Confirm your password"
-                  value={passwordConfirmation}
-                  onChangeText={setPasswordConfirmation}
-                  autoCapitalize="none"
-                  autoCorrect={false}
-                  secureTextEntry
-                  style={{
-                    shadowColor: '#274B8E',
-                    shadowOpacity: 0.10,
-                    shadowRadius: 10,
-                    shadowOffset: { width: 0, height: 3 }
-                  }}
+                <Controller
+                  control={control}
+                  name="passwordConfirmation"
+                  render={({ field: { value, onChange, onBlur } }) => (
+                    <TextInput
+                      testID="signup-password-confirmation-input"
+                      className="px-4 py-4 w-full rounded-xl border border-[#2B42B6] bg-[#13203a] text-[#F1F5F9] placeholder:text-[#708090]"
+                      placeholder="Confirm your password"
+                      value={value}
+                      onChangeText={onChange}
+                      onBlur={onBlur}
+                      autoCapitalize="none"
+                      autoCorrect={false}
+                      secureTextEntry
+                      style={{
+                        shadowColor: '#274B8E',
+                        shadowOpacity: 0.10,
+                        shadowRadius: 10,
+                        shadowOffset: { width: 0, height: 3 }
+                      }}
+                    />
+                  )}
                 />
+                {errors.passwordConfirmation && (
+                  <Text className={fieldErrorClassName} testID="signup-password-confirmation-error">
+                    {errors.passwordConfirmation.message}
+                  </Text>
+                )}
               </View>
             </View>
 
             <TouchableOpacity
               testID="signup-signup-button"
-              className={`w-full py-4 rounded-xl shadow-md mb-8 ${isLoading ? 'bg-[#808080]' : 'bg-cyan-400'}`}
-              onPress={handleSignUp}
-              disabled={isLoading}
+              className={`w-full py-4 rounded-xl shadow-md mb-8 ${isLoading || !isValid ? 'bg-[#808080]' : 'bg-cyan-400'}`}
+              onPress={handleSubmit(onSubmit)}
+              disabled={isLoading || !isValid}
               style={{
                 shadowColor: isLoading ? '#808080' : '#33CFFF',
                 shadowOpacity: isLoading ? 0.12 : 0.25,

--- a/app/onboarding.tsx
+++ b/app/onboarding.tsx
@@ -1,5 +1,6 @@
 import AiOnboardingWizard from '@/components/AiOnboardingWizard';
 import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import LinearGradient from '@/components/ui/LinearGradient';
 import { Colors } from '@/constants/Colors';
 import { useColorScheme } from '@/hooks/useColorScheme';
@@ -11,6 +12,14 @@ import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 
 export default function OnboardingScreen() {
+  return (
+    <ErrorBoundary scope="onboarding">
+      <OnboardingContent />
+    </ErrorBoundary>
+  );
+}
+
+function OnboardingContent() {
   const colorScheme = useColorScheme();
   const colors = Colors[colorScheme ?? 'light'];
   const [showWizard, setShowWizard] = useState(false);

--- a/app/smartGoals/index.tsx
+++ b/app/smartGoals/index.tsx
@@ -1,5 +1,6 @@
 import AiOnboardingWizard from '@/components/AiOnboardingWizard';
 import { PrimaryButton } from '@/components/buttons/';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { LoadingSpinner } from '@/components/loading';
 import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
@@ -7,11 +8,24 @@ import ScrollView from '@/components/util/ScrollView';
 import { useSmartGoals } from '@/hooks/useSmartGoals';
 import { useProfile } from '@/hooks/useUser';
 import { Ionicons } from '@expo/vector-icons';
+import { useQueryClient } from '@tanstack/react-query';
 import { router } from 'expo-router';
 import React, { useState } from 'react';
 import { Pressable, Text, View } from 'react-native';
 
 export default function SmartGoalsScreen() {
+  const queryClient = useQueryClient();
+  return (
+    <ErrorBoundary
+      scope="smart-goals"
+      onReset={() => queryClient.invalidateQueries({ queryKey: ['smartGoals'] })}
+    >
+      <SmartGoalsContent />
+    </ErrorBoundary>
+  );
+}
+
+function SmartGoalsContent() {
   const { data: profile, isLoading: profileLoading } = useProfile();
   const { data: goals, isLoading: goalsLoading, error } = useSmartGoals();
   const [showWizard, setShowWizard] = useState(false);

--- a/app/taskDetail/[id].tsx
+++ b/app/taskDetail/[id].tsx
@@ -1,56 +1,84 @@
 import { UpdateTaskParams } from '@/api/tasks';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { PRIORITY_OPTIONS, PriorityInput } from '@/components/inputs';
 import { LoadingSpinner } from '@/components/loading';
 import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useDeleteTask, useTask, useUpdateTask } from '@/hooks/useTasks';
+import { taskSchema } from '@/models';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useQueryClient } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
-import React, { useEffect, useState } from 'react';
+import React, { useEffect } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { ActivityIndicator, Alert, KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
+import { z } from 'zod';
+
+const editTaskFormSchema = taskSchema.pick({
+  title: true,
+  description: true,
+  priority: true,
+  action_category: true,
+});
+
+type EditTaskFormValues = z.infer<typeof editTaskFormSchema>;
+
+const fieldErrorClassName = 'text-red-400 text-xs mt-1';
 
 export default function TaskDetailScreen() {
+  const queryClient = useQueryClient();
+  return (
+    <ErrorBoundary
+      scope="task-detail"
+      onReset={() => queryClient.invalidateQueries({ queryKey: ['tasks'] })}
+    >
+      <TaskDetailContent />
+    </ErrorBoundary>
+  );
+}
+
+function TaskDetailContent() {
   const { id } = useLocalSearchParams<{ id: string }>();
   const taskId = parseInt(id || '0', 10);
-
-  const [isEditing, setIsEditing] = useState(false);
-  const [taskDetails, setTaskDetails] = useState({
-    title: '',
-    description: '',
-    action_category: 'do' as 'do' | 'defer' | 'delegate',
-    priority: 1
-  });
 
   const updateTaskMutation = useUpdateTask();
   const deleteTaskMutation = useDeleteTask();
   const toast = useToast();
 
-  // Fetch task details
   const { data: task, isLoading, error, refetch } = useTask(taskId);
 
-  // Update local state when task data is loaded
+  const { control, handleSubmit, formState: { errors, isValid }, reset } = useForm<EditTaskFormValues>({
+    resolver: zodResolver(editTaskFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      title: '',
+      description: '',
+      priority: 1,
+      action_category: 'do',
+    },
+  });
+
+  // editingMode: separate ref-like state via reset + a flag
+  const [isEditing, setIsEditing] = React.useState(false);
+
   useEffect(() => {
     if (task) {
-      setTaskDetails({
+      reset({
         title: task.title,
         description: task.description || '',
         action_category: task.action_category,
         priority: task.priority || 1,
       });
     }
-  }, [task]);
+  }, [task, reset]);
 
-  const handleSave = () => {
-    if (!taskDetails.title.trim()) {
-      toast.error('Title is required');
-      return;
-    }
-
+  const onSubmit = (values: EditTaskFormValues) => {
     const updateData: UpdateTaskParams = {
-      title: taskDetails.title.trim(),
-      description: taskDetails.description.trim() || undefined,
-      action_category: taskDetails.action_category,
-      priority: taskDetails.priority
+      title: values.title,
+      description: values.description || undefined,
+      action_category: values.action_category,
+      priority: values.priority,
     };
 
     updateTaskMutation.mutate(
@@ -62,6 +90,18 @@ export default function TaskDetailScreen() {
         },
       }
     );
+  };
+
+  const handleCancelEdit = () => {
+    if (task) {
+      reset({
+        title: task.title,
+        description: task.description || '',
+        action_category: task.action_category,
+        priority: task.priority || 1,
+      });
+    }
+    setIsEditing(false);
   };
 
   const handleDelete = () => {
@@ -83,14 +123,6 @@ export default function TaskDetailScreen() {
         },
       ]
     );
-  };
-
-  const handleCategoryChange = (category: 'do' | 'defer' | 'delegate') => {
-    setTaskDetails(prev => ({ ...prev, action_category: category }));
-  };
-
-  const handlePriorityChange = (priority: number) => {
-    setTaskDetails(prev => ({ ...prev, priority: priority }));
   };
 
   if (isLoading) {
@@ -153,7 +185,7 @@ export default function TaskDetailScreen() {
                 {isEditing ? (
                   <>
                     <Pressable
-                      onPress={() => setIsEditing(false)}
+                      onPress={handleCancelEdit}
                       className="px-4 py-2 rounded-lg border border-[#708090]"
                       disabled={updateTaskMutation.isPending}
                       testID="task-detail-cancel-button"
@@ -161,9 +193,9 @@ export default function TaskDetailScreen() {
                       <Text className="text-[#E6FAFF] font-medium" testID="task-detail-cancel-text">Cancel</Text>
                     </Pressable>
                     <Pressable
-                      onPress={handleSave}
+                      onPress={handleSubmit(onSubmit)}
                       className="flex-row items-center px-4 py-2 bg-cyan-400 rounded-lg"
-                      disabled={updateTaskMutation.isPending}
+                      disabled={!isValid || updateTaskMutation.isPending}
                       testID="task-detail-save-button"
                     >
                       {updateTaskMutation.isPending && (
@@ -218,15 +250,29 @@ export default function TaskDetailScreen() {
             <View className="mb-6">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Title</Text>
               {isEditing ? (
-                <TextInput
-                  className="px-4 py-3 border border-[#33CFFF] rounded-xl text-base text-[#F1F5F9] bg-[#13203a]"
-                  value={taskDetails.title}
-                  onChangeText={(text) => setTaskDetails(prev => ({ ...prev, title: text }))}
-                  placeholder="Task title"
-                  placeholderTextColor="#708090"
-                  editable={!updateTaskMutation.isPending}
-                  testID="task-detail-title-input"
-                />
+                <>
+                  <Controller
+                    control={control}
+                    name="title"
+                    render={({ field: { value, onChange, onBlur } }) => (
+                      <TextInput
+                        className="px-4 py-3 border border-[#33CFFF] rounded-xl text-base text-[#F1F5F9] bg-[#13203a]"
+                        value={value}
+                        onChangeText={onChange}
+                        onBlur={onBlur}
+                        placeholder="Task title"
+                        placeholderTextColor="#708090"
+                        editable={!updateTaskMutation.isPending}
+                        testID="task-detail-title-input"
+                      />
+                    )}
+                  />
+                  {errors.title && (
+                    <Text className={fieldErrorClassName} testID="task-detail-title-error">
+                      {errors.title.message}
+                    </Text>
+                  )}
+                </>
               ) : (
                 <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
                   <Text className="text-[#F1F5F9] text-base" testID="task-detail-title">{task.title}</Text>
@@ -237,17 +283,31 @@ export default function TaskDetailScreen() {
             <View className="mb-6">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Description</Text>
               {isEditing ? (
-                <TextInput
-                  className="px-4 py-3 border border-[#33CFFF] rounded-xl text-base text-[#F1F5F9] bg-[#13203a]"
-                  value={taskDetails.description}
-                  onChangeText={(text) => setTaskDetails(prev => ({ ...prev, description: text }))}
-                  placeholder="Task description (optional)"
-                  placeholderTextColor="#708090"
-                  multiline
-                  numberOfLines={4}
-                  editable={!updateTaskMutation.isPending}
-                  testID="task-detail-description-input"
-                />
+                <>
+                  <Controller
+                    control={control}
+                    name="description"
+                    render={({ field: { value, onChange, onBlur } }) => (
+                      <TextInput
+                        className="px-4 py-3 border border-[#33CFFF] rounded-xl text-base text-[#F1F5F9] bg-[#13203a]"
+                        value={value ?? ''}
+                        onChangeText={onChange}
+                        onBlur={onBlur}
+                        placeholder="Task description (optional)"
+                        placeholderTextColor="#708090"
+                        multiline
+                        numberOfLines={4}
+                        editable={!updateTaskMutation.isPending}
+                        testID="task-detail-description-input"
+                      />
+                    )}
+                  />
+                  {errors.description && (
+                    <Text className={fieldErrorClassName}>
+                      {errors.description.message}
+                    </Text>
+                  )}
+                </>
               ) : (
                 <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
                   <Text className="text-[#F1F5F9] text-base" testID="task-detail-description">
@@ -260,10 +320,16 @@ export default function TaskDetailScreen() {
             <View className="mb-6">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Priority</Text>
               {isEditing ? (
-                <PriorityInput
-                  value={taskDetails.priority}
-                  onChange={handlePriorityChange}
-                  disabled={updateTaskMutation.isPending}
+                <Controller
+                  control={control}
+                  name="priority"
+                  render={({ field: { value, onChange } }) => (
+                    <PriorityInput
+                      value={value ?? 1}
+                      onChange={onChange}
+                      disabled={updateTaskMutation.isPending}
+                    />
+                  )}
                 />
               ) : (
                 <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
@@ -277,28 +343,34 @@ export default function TaskDetailScreen() {
             <View className="mb-6">
               <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Action Category</Text>
               {isEditing ? (
-                <View className="flex-row gap-2">
-                  {(['do', 'defer', 'delegate'] as const).map((category) => (
-                    <Pressable
-                      key={category}
-                      onPress={() => handleCategoryChange(category)}
-                      className={`flex-1 py-3 px-4 rounded-lg border ${taskDetails.action_category === category
-                        ? 'border-[#33CFFF] bg-cyan-400'
-                        : 'border-[#708090] bg-[#13203a]'
-                        }`}
-                      disabled={updateTaskMutation.isPending}
-                    >
-                      <Text
-                        className={`text-center font-medium capitalize ${taskDetails.action_category === category
-                          ? 'text-[#021A40]'
-                          : 'text-[#E6FAFF]'
-                          }`}
-                      >
-                        {category}
-                      </Text>
-                    </Pressable>
-                  ))}
-                </View>
+                <Controller
+                  control={control}
+                  name="action_category"
+                  render={({ field: { value, onChange } }) => (
+                    <View className="flex-row gap-2">
+                      {(['do', 'defer', 'delegate'] as const).map((category) => (
+                        <Pressable
+                          key={category}
+                          onPress={() => onChange(category)}
+                          className={`flex-1 py-3 px-4 rounded-lg border ${value === category
+                            ? 'border-[#33CFFF] bg-cyan-400'
+                            : 'border-[#708090] bg-[#13203a]'
+                            }`}
+                          disabled={updateTaskMutation.isPending}
+                        >
+                          <Text
+                            className={`text-center font-medium capitalize ${value === category
+                              ? 'text-[#021A40]'
+                              : 'text-[#E6FAFF]'
+                              }`}
+                          >
+                            {category}
+                          </Text>
+                        </Pressable>
+                      ))}
+                    </View>
+                  )}
+                />
               ) : (
                 <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
                   <Text className="text-[#F1F5F9] text-base capitalize">{task.action_category}</Text>

--- a/components/AiOnboardingWizard.tsx
+++ b/components/AiOnboardingWizard.tsx
@@ -6,12 +6,42 @@ import { useAiResponseHelpers } from '@/hooks/useAi';
 import { useAiProxy } from '@/hooks/useAiProxy';
 import { useCreateMultipleSmartGoals } from '@/hooks/useSmartGoals';
 import { useCompleteOnboarding, useProfile, useUpdateProfile } from '@/hooks/useUser';
+import { profileSchema } from '@/models';
 import { router } from 'expo-router';
 import React, { useEffect, useState } from 'react';
 import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
+import { z } from 'zod';
 import { AiResponseStep, ConfirmationStep, GoalDescriptionStep, ProfileDetailsStep } from './AiOnboardingWizardSteps';
 import ProgressBar from './ProgressBar';
+
+export const onboardingProfileSchema = profileSchema
+  .pick({
+    first_name: true,
+    last_name: true,
+    work_role: true,
+    education: true,
+    desires: true,
+    limiting_beliefs: true,
+  })
+  .extend({
+    first_name: z.string().trim().min(1, 'First name is required').max(100),
+    last_name: z.string().trim().min(1, 'Last name is required').max(100),
+    work_role: z.string().trim().min(1, 'Work role is required').max(200),
+    education: z.string().trim().min(1, 'Education is required').max(200),
+  });
+
+export type OnboardingProfileFormValues = z.infer<typeof onboardingProfileSchema>;
+
+export const onboardingGoalSchema = z.object({
+  goalDescription: z
+    .string()
+    .trim()
+    .min(10, 'Please describe your goal in at least 10 characters')
+    .max(2000),
+});
+
+export type OnboardingGoalFormValues = z.infer<typeof onboardingGoalSchema>;
 
 export interface SMARTGoalData {
   title: string;
@@ -41,14 +71,6 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
   const [isLoading, setIsLoading] = useState(false);
   const updateProfile = useUpdateProfile();
   const { data: profile } = useProfile();
-  const [profileData, setProfileData] = useState<ProfileUpdateData>({
-    first_name: profile?.first_name || '',
-    last_name: profile?.last_name || '',
-    work_role: profile?.work_role || '',
-    education: profile?.education || '',
-    desires: profile?.desires || '',
-    limiting_beliefs: profile?.limiting_beliefs || ''
-  });
 
   const aiProxy = useAiProxy();
   const createMultipleSmartGoals = useCreateMultipleSmartGoals();
@@ -56,7 +78,6 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
   const { isSmartGoalResponse, formatMultiPeriodSmartGoalResponse } = useAiResponseHelpers();
   const toast = useToast();
 
-  // Handle completed job results
   useEffect(() => {
     if (aiProxy.isJobComplete && aiProxy.jobStatus?.result) {
       setAiResponse(aiProxy.jobStatus.result);
@@ -89,29 +110,22 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
 
   const currentStep = steps[currentStepIndex];
 
-  // Check if profileData has changed from current profile
-  const hasProfileChanged = (): boolean => {
-    if (!profile) return false;
-
-    return Object.keys(profileData).some(key =>
-      profileData[key as keyof ProfileUpdateData] !== profile[key as keyof Profile]
+  const hasProfileChanged = (values: OnboardingProfileFormValues): boolean => {
+    if (!profile) return true;
+    return (Object.keys(values) as (keyof OnboardingProfileFormValues)[]).some(
+      key => values[key] !== profile[key as keyof Profile],
     );
   };
 
-  const handleSubmitProfileDetails = async () => {
-    if (!profileData.first_name?.trim() || !profileData.last_name?.trim() || !profileData.work_role?.trim() || !profileData.education?.trim()) {
-      toast.error('Please fill in all required fields (First Name, Last Name, Work Role, and Education).');
-      return;
-    }
-
-    if (!hasProfileChanged()) {
+  const handleProfileSubmit = async (values: OnboardingProfileFormValues): Promise<void> => {
+    if (!hasProfileChanged(values)) {
       setCurrentStepIndex(1);
       return;
     }
 
     setIsLoading(true);
     try {
-      await updateProfile.mutateAsync(profileData);
+      await updateProfile.mutateAsync(values as ProfileUpdateData);
       setCurrentStepIndex(1);
     } catch {
       // apiRequest interceptor surfaces the error toast
@@ -120,15 +134,11 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
     }
   };
 
-  const handleSubmitGoalDescription = async () => {
-    if (!goalDescription.trim()) {
-      toast.error('Please describe what you want to achieve.');
-      return;
-    }
-
+  const handleGoalDescriptionSubmit = async (values: OnboardingGoalFormValues): Promise<void> => {
+    setGoalDescription(values.goalDescription);
     try {
-      setIsLoading(true)
-      await aiProxy.processAiRequest(goalDescription.trim());
+      setIsLoading(true);
+      await aiProxy.processAiRequest(values.goalDescription);
       setCurrentStepIndex(2);
     } catch {
       // apiRequest interceptor surfaces the error toast
@@ -191,21 +201,24 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
       case 'profile-details':
         return (
           <ProfileDetailsStep
-            profileData={profileData}
-            setProfileData={setProfileData}
-            handleSubmit={handleSubmitProfileDetails}
-            isLoading={false}
+            initialValues={{
+              first_name: profile?.first_name || '',
+              last_name: profile?.last_name || '',
+              work_role: profile?.work_role || '',
+              education: profile?.education || '',
+              desires: profile?.desires || '',
+              limiting_beliefs: profile?.limiting_beliefs || '',
+            }}
+            onSubmit={handleProfileSubmit}
+            isLoading={isLoading}
           />
         );
       case 'goal-description':
         return (
           <GoalDescriptionStep
-            goalDescription={goalDescription}
-            setGoalDescription={setGoalDescription}
-            handleSubmit={handleSubmitGoalDescription}
+            onSubmit={handleGoalDescriptionSubmit}
             isLoading={aiProxy.isLoading}
             progress={aiProxy.progress}
-            isJobComplete={aiProxy.isJobComplete}
             isJobFailed={aiProxy.isJobFailed}
           />
         );
@@ -237,7 +250,6 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
     <LinearGradient>
       <SafeAreaView className="flex-1">
         <ScrollView className="flex-1 p-5" showsVerticalScrollIndicator={false}>
-          {/* Header */}
           <View className="items-center mb-8">
             <Text className="mb-2 text-2xl font-bold text-center text-[#E6FAFF]">
               {currentStep.title}
@@ -252,4 +264,4 @@ export default function AiOnboardingWizard({ onComplete }: OnboardingWizardProps
       </SafeAreaView>
     </LinearGradient>
   );
-} 
+}

--- a/components/AiOnboardingWizardSteps.tsx
+++ b/components/AiOnboardingWizardSteps.tsx
@@ -2,99 +2,121 @@ import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
 import { LoadingSkeleton, LoadingSpinner } from '@/components/loading';
 import { setSkippedOnboarding } from '@/utils/handleSkipOnboarding';
 import { Ionicons } from '@expo/vector-icons';
+import { zodResolver } from '@hookform/resolvers/zod';
 import { router } from 'expo-router';
 import React from "react";
+import { Controller, useForm } from 'react-hook-form';
 import { Text, TextInput, TouchableOpacity, View } from "react-native";
+import {
+  OnboardingGoalFormValues,
+  OnboardingProfileFormValues,
+  onboardingGoalSchema,
+  onboardingProfileSchema,
+} from './AiOnboardingWizard';
 
 export interface ProfileDetailsStepProps {
-  profileData: {
-    first_name?: string;
-    last_name?: string;
-    work_role?: string;
-    education?: string;
-    desires?: string;
-    limiting_beliefs?: string;
-  };
-  setProfileData: (data: any) => void;
-  handleSubmit: () => void;
+  initialValues: OnboardingProfileFormValues;
+  onSubmit: (values: OnboardingProfileFormValues) => Promise<void> | void;
   isLoading: boolean;
 }
 
 export interface GoalDescriptionStepProps {
-  goalDescription: string,
-  setGoalDescription: (text: string) => void,
-  handleSubmit: () => void,
-  isLoading: boolean,
-  progress?: number,
-  isJobComplete?: boolean,
-  isJobFailed?: boolean
+  onSubmit: (values: OnboardingGoalFormValues) => Promise<void> | void;
+  isLoading: boolean;
+  progress?: number;
+  isJobFailed?: boolean;
 }
 
 export interface AiResponseStepProps {
-  aiResponse: any,
-  isSmartGoalResponse: (response: any) => boolean,
-  formatMultiPeriodSmartGoalResponse: (response: any) => Record<string, Record<string, string>>,
-  handleEditGoal: () => void,
-  setCurrentStepIndex: (index: number) => void
-  isLoading: boolean
+  aiResponse: any;
+  isSmartGoalResponse: (response: any) => boolean;
+  formatMultiPeriodSmartGoalResponse: (response: any) => Record<string, Record<string, string>>;
+  handleEditGoal: () => void;
+  setCurrentStepIndex: (index: number) => void;
+  isLoading: boolean;
 }
 
 export interface ConfirmationStepProps {
-  aiResponse: any,
-  isSmartGoalResponse: (response: any) => boolean,
-  formatMultiPeriodSmartGoalResponse: (response: any) => Record<string, Record<string, string>>,
-  handleEditGoal: () => void,
-  handleConfirmGoal: () => void
+  aiResponse: any;
+  isSmartGoalResponse: (response: any) => boolean;
+  formatMultiPeriodSmartGoalResponse: (response: any) => Record<string, Record<string, string>>;
+  handleEditGoal: () => void;
+  handleConfirmGoal: () => void;
 }
 
 const handleSkippingOnboarding = () => {
-  setSkippedOnboarding()
-  router.replace('/(tabs)')
-}
+  setSkippedOnboarding();
+  router.replace('/(tabs)');
+};
 
-const GoalDescriptionStep = ({ goalDescription, setGoalDescription, handleSubmit, isLoading, progress = 0, isJobComplete = false, isJobFailed = false }: GoalDescriptionStepProps) => (
-  <View className="">
-    <View className="mb-5">
-      <Text className="mb-2 text-lg font-semibold text-[#F1F5F9]">
-        Describe what you want to achieve
-      </Text>
-      <Text className="mb-3 text-sm text-[#E6FAFF] opacity-70">
-        Tell us what you want to accomplish. We&apos;ll create SMART goals for 1 month, 3 months, and 6 months. For example: &ldquo;I want to improve my fitness and run a marathon&rdquo; or &ldquo;I want to learn web development and build my own website&rdquo;
-      </Text>
-      <TextInput
-        className="border border-cyan-400 rounded-lg p-3 text-base min-h-[120px] text-[#E6FAFF] bg-slate-800"
-        placeholder="e.g., I want to improve my fitness and run a marathon, or learn web development and build my own website..."
-        placeholderTextColor="#708090"
-        value={goalDescription}
-        onChangeText={setGoalDescription}
-        multiline
-        numberOfLines={6}
-        textAlignVertical="top"
-      />
-    </View>
+const fieldErrorClassName = 'mt-1 text-xs text-red-400';
+const inputClassName = 'border border-cyan-400 rounded-lg p-3 text-base text-[#E6FAFF] bg-slate-800';
 
-    <View className='gap-4'>
-      <PrimaryButton
-        title={isLoading ? `Processing... ${progress}%` : "Generate SMART Goals"}
-        loadingText="Generating your SMART goal..."
-        onPress={handleSubmit}
-        isLoading={isLoading}
-        icon="sparkles"
-        className="mt-5"
-      />
-      {isJobFailed && (
-        <Text className="mt-2 text-sm text-red-400">
-          Failed to generate goals. Please try again.
+const GoalDescriptionStep = ({ onSubmit, isLoading, progress = 0, isJobFailed = false }: GoalDescriptionStepProps) => {
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<OnboardingGoalFormValues>({
+    resolver: zodResolver(onboardingGoalSchema),
+    mode: 'onChange',
+    defaultValues: { goalDescription: '' },
+  });
+
+  return (
+    <View className="">
+      <View className="mb-5">
+        <Text className="mb-2 text-lg font-semibold text-[#F1F5F9]">
+          Describe what you want to achieve
         </Text>
-      )}
-      <SecondaryButton
-        testID="ai-onboarding-skip-button"
-        title="Skip For Now"
-        onPress={handleSkippingOnboarding}
-      />
+        <Text className="mb-3 text-sm text-[#E6FAFF] opacity-70">
+          Tell us what you want to accomplish. We&apos;ll create SMART goals for 1 month, 3 months, and 6 months. For example: &ldquo;I want to improve my fitness and run a marathon&rdquo; or &ldquo;I want to learn web development and build my own website&rdquo;
+        </Text>
+        <Controller
+          control={control}
+          name="goalDescription"
+          render={({ field: { value, onChange, onBlur } }) => (
+            <TextInput
+              className="border border-cyan-400 rounded-lg p-3 text-base min-h-[120px] text-[#E6FAFF] bg-slate-800"
+              placeholder="e.g., I want to improve my fitness and run a marathon, or learn web development and build my own website..."
+              placeholderTextColor="#708090"
+              value={value}
+              onChangeText={onChange}
+              onBlur={onBlur}
+              multiline
+              numberOfLines={6}
+              textAlignVertical="top"
+              testID="onboarding-goal-description-input"
+            />
+          )}
+        />
+        {errors.goalDescription && (
+          <Text className={fieldErrorClassName} testID="onboarding-goal-description-error">
+            {errors.goalDescription.message}
+          </Text>
+        )}
+      </View>
+
+      <View className='gap-4'>
+        <PrimaryButton
+          title={isLoading ? `Processing... ${progress}%` : "Generate SMART Goals"}
+          loadingText="Generating your SMART goal..."
+          onPress={handleSubmit(onSubmit)}
+          isLoading={isLoading}
+          disabled={!isValid || isLoading}
+          icon="sparkles"
+          className="mt-5"
+        />
+        {isJobFailed && (
+          <Text className="mt-2 text-sm text-red-400">
+            Failed to generate goals. Please try again.
+          </Text>
+        )}
+        <SecondaryButton
+          testID="ai-onboarding-skip-button"
+          title="Skip For Now"
+          onPress={handleSkippingOnboarding}
+        />
+      </View>
     </View>
-  </View>
-);
+  );
+};
 
 const AiResponseStep = ({ aiResponse, isSmartGoalResponse, formatMultiPeriodSmartGoalResponse, handleEditGoal, setCurrentStepIndex, isLoading }: AiResponseStepProps) => {
   if (!isLoading && (!aiResponse || !isSmartGoalResponse(aiResponse))) {
@@ -254,129 +276,194 @@ const ConfirmationStep = ({ aiResponse, isSmartGoalResponse, formatMultiPeriodSm
   </View>
 );
 
-const ProfileDetailsStep = ({ profileData, setProfileData, handleSubmit, isLoading }: ProfileDetailsStepProps) => (
-  <View className="">
+const ProfileDetailsStep = ({ initialValues, onSubmit, isLoading }: ProfileDetailsStepProps) => {
+  const { control, handleSubmit, formState: { errors, isValid } } = useForm<OnboardingProfileFormValues>({
+    resolver: zodResolver(onboardingProfileSchema),
+    mode: 'onChange',
+    defaultValues: initialValues,
+  });
+
+  return (
     <View className="">
-      {/* First Name */}
-      <View className="mb-4">
-        <Text testID="first-name-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
-          First Name *
-        </Text>
-        <TextInput
-          testID="first-name-input"
-          className="border border-cyan-400 rounded-lg p-3 text-base text-[#E6FAFF] bg-slate-800"
-          placeholder="Enter your first name"
-          placeholderTextColor="#708090"
-          value={profileData.first_name || ''}
-          onChangeText={(text) => setProfileData({ ...profileData, first_name: text })}
-        />
+      <View className="">
+        <View className="mb-4">
+          <Text testID="first-name-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
+            First Name *
+          </Text>
+          <Controller
+            control={control}
+            name="first_name"
+            render={({ field: { value, onChange, onBlur } }) => (
+              <TextInput
+                testID="first-name-input"
+                className={inputClassName}
+                placeholder="Enter your first name"
+                placeholderTextColor="#708090"
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+              />
+            )}
+          />
+          {errors.first_name && (
+            <Text className={fieldErrorClassName} testID="first-name-error">
+              {errors.first_name.message}
+            </Text>
+          )}
+        </View>
+
+        <View className="mb-4">
+          <Text testID="last-name-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
+            Last Name *
+          </Text>
+          <Controller
+            control={control}
+            name="last_name"
+            render={({ field: { value, onChange, onBlur } }) => (
+              <TextInput
+                testID="last-name-input"
+                className={inputClassName}
+                placeholder="Enter your last name"
+                placeholderTextColor="#708090"
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+              />
+            )}
+          />
+          {errors.last_name && (
+            <Text className={fieldErrorClassName} testID="last-name-error">
+              {errors.last_name.message}
+            </Text>
+          )}
+        </View>
+
+        <View className="mb-4">
+          <Text testID="work-role-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
+            Work Role *
+          </Text>
+          <Controller
+            control={control}
+            name="work_role"
+            render={({ field: { value, onChange, onBlur } }) => (
+              <TextInput
+                testID="work-role-input"
+                className={inputClassName}
+                placeholder="e.g., Software Engineer, Marketing Manager, Student"
+                placeholderTextColor="#708090"
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+              />
+            )}
+          />
+          {errors.work_role && (
+            <Text className={fieldErrorClassName} testID="work-role-error">
+              {errors.work_role.message}
+            </Text>
+          )}
+        </View>
+
+        <View className="mb-4">
+          <Text testID="education-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
+            Education *
+          </Text>
+          <Controller
+            control={control}
+            name="education"
+            render={({ field: { value, onChange, onBlur } }) => (
+              <TextInput
+                testID="education-input"
+                className={inputClassName}
+                placeholder="e.g., Bachelor's in Computer Science, High School Diploma"
+                placeholderTextColor="#708090"
+                value={value}
+                onChangeText={onChange}
+                onBlur={onBlur}
+              />
+            )}
+          />
+          {errors.education && (
+            <Text className={fieldErrorClassName} testID="education-error">
+              {errors.education.message}
+            </Text>
+          )}
+        </View>
+
+        <View className="mb-4">
+          <Text testID="desires-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
+            Desires (Optional)
+          </Text>
+          <Text testID="desires-description" className="mb-2 text-xs text-[#708090]">
+            What do you want to achieve? What drives you? This helps us provide better coaching.
+          </Text>
+          <Controller
+            control={control}
+            name="desires"
+            render={({ field: { value, onChange, onBlur } }) => (
+              <TextInput
+                testID="desires-input"
+                className="border border-cyan-400 rounded-lg p-3 text-base min-h-[80px] text-[#E6FAFF] bg-slate-800"
+                placeholder="e.g., I want to be financially independent, I want to make a positive impact..."
+                placeholderTextColor="#708090"
+                value={value ?? ''}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                multiline
+                numberOfLines={3}
+                textAlignVertical="top"
+              />
+            )}
+          />
+        </View>
+
+        <View className="mb-4">
+          <Text testID="limiting-beliefs-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
+            Limiting Beliefs (Optional)
+          </Text>
+          <Text testID="limiting-beliefs-description" className="mb-2 text-xs text-[#708090]">
+            What holds you back? What do you struggle with? This helps us provide better coaching.
+          </Text>
+          <Controller
+            control={control}
+            name="limiting_beliefs"
+            render={({ field: { value, onChange, onBlur } }) => (
+              <TextInput
+                testID="limiting-beliefs-input"
+                className="border border-cyan-400 rounded-lg p-3 text-base min-h-[80px] text-[#E6FAFF] bg-slate-800"
+                placeholder="e.g., I'm not good enough, I don't have enough time..."
+                placeholderTextColor="#708090"
+                value={value ?? ''}
+                onChangeText={onChange}
+                onBlur={onBlur}
+                multiline
+                numberOfLines={3}
+                textAlignVertical="top"
+              />
+            )}
+          />
+        </View>
       </View>
 
-      {/* Last Name */}
-      <View className="mb-4">
-        <Text testID="last-name-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
-          Last Name *
-        </Text>
-        <TextInput
-          testID="last-name-input"
-          className="border border-cyan-400 rounded-lg p-3 text-base text-[#E6FAFF] bg-slate-800"
-          placeholder="Enter your last name"
-          placeholderTextColor="#708090"
-          value={profileData.last_name || ''}
-          onChangeText={(text) => setProfileData({ ...profileData, last_name: text })}
+      <View className='gap-4'>
+        <PrimaryButton
+          testID="profile-continue-button"
+          title="Continue"
+          loadingText="Saving profile..."
+          onPress={handleSubmit(onSubmit)}
+          isLoading={isLoading}
+          disabled={!isValid || isLoading}
+          icon="arrow-forward"
+          className="mt-5"
         />
-      </View>
-
-      {/* Work Role */}
-      <View className="mb-4">
-        <Text testID="work-role-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
-          Work Role *
-        </Text>
-        <TextInput
-          testID="work-role-input"
-          className="border border-cyan-400 rounded-lg p-3 text-base text-[#E6FAFF] bg-slate-800"
-          placeholder="e.g., Software Engineer, Marketing Manager, Student"
-          placeholderTextColor="#708090"
-          value={profileData.work_role || ''}
-          onChangeText={(text) => setProfileData({ ...profileData, work_role: text })}
-        />
-      </View>
-
-      {/* Education */}
-      <View className="mb-4">
-        <Text testID="education-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
-          Education *
-        </Text>
-        <TextInput
-          testID="education-input"
-          className="border border-cyan-400 rounded-lg p-3 text-base text-[#E6FAFF] bg-slate-800"
-          placeholder="e.g., Bachelor's in Computer Science, High School Diploma"
-          placeholderTextColor="#708090"
-          value={profileData.education || ''}
-          onChangeText={(text) => setProfileData({ ...profileData, education: text })}
-        />
-      </View>
-
-      {/* Desires */}
-      <View className="mb-4">
-        <Text testID="desires-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
-          Desires (Optional)
-        </Text>
-        <Text testID="desires-description" className="mb-2 text-xs text-[#708090]">
-          What do you want to achieve? What drives you? This helps us provide better coaching.
-        </Text>
-        <TextInput
-          testID="desires-input"
-          className="border border-cyan-400 rounded-lg p-3 text-base min-h-[80px] text-[#E6FAFF] bg-slate-800"
-          placeholder="e.g., I want to be financially independent, I want to make a positive impact..."
-          placeholderTextColor="#708090"
-          value={profileData.desires || ''}
-          onChangeText={(text) => setProfileData({ ...profileData, desires: text })}
-          multiline
-          numberOfLines={3}
-          textAlignVertical="top"
-        />
-      </View>
-
-      {/* Limiting Beliefs */}
-      <View className="mb-4">
-        <Text testID="limiting-beliefs-label" className="mb-2 text-sm font-medium text-[#E6FAFF]">
-          Limiting Beliefs (Optional)
-        </Text>
-        <Text testID="limiting-beliefs-description" className="mb-2 text-xs text-[#708090]">
-          What holds you back? What do you struggle with? This helps us provide better coaching.
-        </Text>
-        <TextInput
-          testID="limiting-beliefs-input"
-          className="border border-cyan-400 rounded-lg p-3 text-base min-h-[80px] text-[#E6FAFF] bg-slate-800"
-          placeholder="e.g., I'm not good enough, I don't have enough time..."
-          placeholderTextColor="#708090"
-          value={profileData.limiting_beliefs || ''}
-          onChangeText={(text) => setProfileData({ ...profileData, limiting_beliefs: text })}
-          multiline
-          numberOfLines={3}
-          textAlignVertical="top"
+        <SecondaryButton
+          testID="ai-onboarding-skip-button"
+          title="Skip For Now"
+          onPress={handleSkippingOnboarding}
         />
       </View>
     </View>
-
-    <View className='gap-4'>
-      <PrimaryButton
-        testID="profile-continue-button"
-        title="Continue"
-        loadingText="Saving profile..."
-        onPress={handleSubmit}
-        isLoading={isLoading}
-        icon="arrow-forward"
-        className="mt-5"
-      />
-      <SecondaryButton
-        testID="ai-onboarding-skip-button"
-        title="Skip For Now"
-        onPress={handleSkippingOnboarding}
-      />
-    </View>
-  </View>
-);
+  );
+};
 
 export { AiResponseStep, ConfirmationStep, GoalDescriptionStep, ProfileDetailsStep };

--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -1,0 +1,82 @@
+import { reportError } from '@/utils/reportError';
+import { Ionicons } from '@expo/vector-icons';
+import React, { Component, ErrorInfo, ReactNode } from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+export interface ErrorBoundaryProps {
+  children: ReactNode;
+  fallback?: (args: { error: Error; reset: () => void }) => ReactNode;
+  onReset?: () => void;
+  onError?: (error: Error, info: ErrorInfo) => void;
+  scope?: string;
+}
+
+interface ErrorBoundaryState {
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  state: ErrorBoundaryState = { error: null };
+
+  static getDerivedStateFromError(error: Error): ErrorBoundaryState {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    reportError(error, { scope: this.props.scope, componentStack: info.componentStack });
+    this.props.onError?.(error, info);
+  }
+
+  reset = () => {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  };
+
+  render() {
+    const { error } = this.state;
+    if (!error) {
+      return this.props.children;
+    }
+
+    if (this.props.fallback) {
+      return this.props.fallback({ error, reset: this.reset });
+    }
+
+    return <DefaultFallback error={error} reset={this.reset} />;
+  }
+}
+
+function DefaultFallback({ error, reset }: { error: Error; reset: () => void }) {
+  return (
+    <View
+      testID="error-boundary-fallback"
+      className="flex-1 items-center justify-center p-6 bg-[#021A40]"
+    >
+      <View className="items-center mb-6">
+        <Ionicons name="alert-circle-outline" size={56} color="#33CFFF" />
+        <Text
+          className="mt-4 text-2xl font-semibold text-[#F1F5F9] text-center"
+          testID="error-boundary-title"
+        >
+          Something went wrong
+        </Text>
+        <Text
+          className="mt-2 text-base text-[#E6FAFF] text-center"
+          testID="error-boundary-message"
+        >
+          {error.message || 'An unexpected error occurred. Please try again.'}
+        </Text>
+      </View>
+
+      <Pressable
+        onPress={reset}
+        className="px-6 py-3 bg-cyan-400 rounded-xl"
+        testID="error-boundary-retry-button"
+      >
+        <Text className="text-[#021A40] font-semibold text-base">Try Again</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+export default ErrorBoundary;

--- a/components/ProfileEditForm.tsx
+++ b/components/ProfileEditForm.tsx
@@ -2,11 +2,27 @@ import { ProfileUpdateData } from '@/api/users';
 import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
+import { profileSchema } from '@/models';
 import { Ionicons } from '@expo/vector-icons';
+import { zodResolver } from '@hookform/resolvers/zod';
 import React, { useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAvoidingView, Modal, Platform, Pressable, ScrollView as RNScrollView, Text, TextInput, TouchableOpacity, View } from 'react-native';
+import { z } from 'zod';
 
-// Common timezones list
+// Form schema: pick the editable fields off the canonical profile model.
+const profileEditFormSchema = profileSchema.pick({
+  first_name: true,
+  last_name: true,
+  work_role: true,
+  education: true,
+  desires: true,
+  limiting_beliefs: true,
+  timezone: true,
+});
+
+type ProfileEditFormValues = z.infer<typeof profileEditFormSchema>;
+
 const TIMEZONES = [
   { value: 'Pacific/Honolulu', label: 'Hawaii (HST)' },
   { value: 'America/Anchorage', label: 'Alaska (AKST)' },
@@ -32,7 +48,6 @@ const TIMEZONES = [
   { value: 'UTC', label: 'UTC' },
 ];
 
-// Get the device's timezone
 const getDeviceTimezone = (): string => {
   try {
     return Intl.DateTimeFormat().resolvedOptions().timeZone;
@@ -41,7 +56,6 @@ const getDeviceTimezone = (): string => {
   }
 };
 
-// Get label for timezone value
 const getTimezoneLabel = (value: string): string => {
   const tz = TIMEZONES.find(t => t.value === value);
   return tz ? tz.label : value;
@@ -64,32 +78,28 @@ interface ProfileEditFormProps {
   onSuccess: (formData: ProfileUpdateData) => Promise<void>;
 }
 
+const fieldErrorClassName = 'text-red-400 text-xs mt-1 mb-3';
+const inputClassName = 'bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-1';
+
 export default function ProfileEditForm({ profile, isLoading, onCancel, onSuccess }: ProfileEditFormProps) {
   const deviceTimezone = getDeviceTimezone();
-
-  const [formData, setFormData] = useState<ProfileUpdateData>({
-    first_name: profile.first_name || '',
-    last_name: profile.last_name || '',
-    work_role: profile.work_role || '',
-    education: profile.education || '',
-    desires: profile.desires || '',
-    limiting_beliefs: profile.limiting_beliefs || '',
-    timezone: profile.timezone || deviceTimezone,
-  });
-
   const [showTimezonePicker, setShowTimezonePicker] = useState(false);
 
-  const handleInputChange = (field: keyof ProfileUpdateData, value: string) => {
-    setFormData(prev => ({
-      ...prev,
-      [field]: value,
-    }));
-  };
+  const { control, handleSubmit, formState: { errors } } = useForm<ProfileEditFormValues>({
+    resolver: zodResolver(profileEditFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      first_name: profile.first_name || '',
+      last_name: profile.last_name || '',
+      work_role: profile.work_role || '',
+      education: profile.education || '',
+      desires: profile.desires || '',
+      limiting_beliefs: profile.limiting_beliefs || '',
+      timezone: profile.timezone || deviceTimezone,
+    },
+  });
 
-  const handleTimezoneSelect = (timezone: string) => {
-    handleInputChange('timezone', timezone);
-    setShowTimezonePicker(false);
-  };
+  const onSubmit = (values: ProfileEditFormValues) => onSuccess(values);
 
   return (
     <LinearGradient>
@@ -110,56 +120,153 @@ export default function ProfileEditForm({ profile, isLoading, onCancel, onSucces
 
             <View className="bg-[#2B42B6] rounded-2xl p-5 mb-4 shadow-md border border-[#33CFFF]" style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}>
               <Text className="text-[#708090] text-sm font-medium mb-1">First Name</Text>
-              <TextInput
-                className="bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-4"
-                value={formData.first_name}
-                onChangeText={(value) => handleInputChange('first_name', value)}
-                placeholder="Enter first name"
-                placeholderTextColor="#708090"
-                testID="profile-edit-first-name"
+              <Controller
+                control={control}
+                name="first_name"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className={inputClassName}
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Enter first name"
+                    placeholderTextColor="#708090"
+                    testID="profile-edit-first-name"
+                  />
+                )}
               />
-
-              <Text className="text-[#708090] text-sm font-medium mb-1">Last Name</Text>
-              <TextInput
-                className="bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-4"
-                value={formData.last_name}
-                onChangeText={(value) => handleInputChange('last_name', value)}
-                placeholder="Enter last name"
-                placeholderTextColor="#708090"
-                testID="profile-edit-last-name"
-              />
-
-              <Text className="text-[#708090] text-sm font-medium mb-1">Work Role</Text>
-              <TextInput
-                className="bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-4"
-                value={formData.work_role}
-                onChangeText={(value) => handleInputChange('work_role', value)}
-                placeholder="Enter work role"
-                placeholderTextColor="#708090"
-                testID="profile-edit-work-role"
-              />
-
-              <Text className="text-[#708090] text-sm font-medium mb-1">Education</Text>
-              <TextInput
-                className="bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-4"
-                value={formData.education}
-                onChangeText={(value) => handleInputChange('education', value)}
-                placeholder="Enter education"
-                placeholderTextColor="#708090"
-                testID="profile-edit-education"
-              />
-
-              <Text className="text-[#708090] text-sm font-medium mb-1">Timezone</Text>
-              <TouchableOpacity
-                className="bg-[#1A2B5C] rounded-xl p-3 flex-row items-center justify-between"
-                onPress={() => setShowTimezonePicker(true)}
-                testID="profile-edit-timezone-button"
-              >
-                <Text className="text-[#F1F5F9] text-base">
-                  {getTimezoneLabel(formData.timezone || deviceTimezone)}
+              {errors.first_name && (
+                <Text className={fieldErrorClassName} testID="profile-edit-first-name-error">
+                  {errors.first_name.message}
                 </Text>
-                <Ionicons name="chevron-down" size={20} color="#708090" />
-              </TouchableOpacity>
+              )}
+
+              <Text className="text-[#708090] text-sm font-medium mb-1 mt-3">Last Name</Text>
+              <Controller
+                control={control}
+                name="last_name"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className={inputClassName}
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Enter last name"
+                    placeholderTextColor="#708090"
+                    testID="profile-edit-last-name"
+                  />
+                )}
+              />
+              {errors.last_name && (
+                <Text className={fieldErrorClassName} testID="profile-edit-last-name-error">
+                  {errors.last_name.message}
+                </Text>
+              )}
+
+              <Text className="text-[#708090] text-sm font-medium mb-1 mt-3">Work Role</Text>
+              <Controller
+                control={control}
+                name="work_role"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className={inputClassName}
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Enter work role"
+                    placeholderTextColor="#708090"
+                    testID="profile-edit-work-role"
+                  />
+                )}
+              />
+              {errors.work_role && (
+                <Text className={fieldErrorClassName} testID="profile-edit-work-role-error">
+                  {errors.work_role.message}
+                </Text>
+              )}
+
+              <Text className="text-[#708090] text-sm font-medium mb-1 mt-3">Education</Text>
+              <Controller
+                control={control}
+                name="education"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className={inputClassName}
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="Enter education"
+                    placeholderTextColor="#708090"
+                    testID="profile-edit-education"
+                  />
+                )}
+              />
+              {errors.education && (
+                <Text className={fieldErrorClassName} testID="profile-edit-education-error">
+                  {errors.education.message}
+                </Text>
+              )}
+
+              <Text className="text-[#708090] text-sm font-medium mb-1 mt-3">Timezone</Text>
+              <Controller
+                control={control}
+                name="timezone"
+                render={({ field: { value, onChange } }) => (
+                  <>
+                    <TouchableOpacity
+                      className="bg-[#1A2B5C] rounded-xl p-3 flex-row items-center justify-between"
+                      onPress={() => setShowTimezonePicker(true)}
+                      testID="profile-edit-timezone-button"
+                    >
+                      <Text className="text-[#F1F5F9] text-base">
+                        {getTimezoneLabel(value || deviceTimezone)}
+                      </Text>
+                      <Ionicons name="chevron-down" size={20} color="#708090" />
+                    </TouchableOpacity>
+                    <Modal
+                      visible={showTimezonePicker}
+                      transparent
+                      animationType="fade"
+                      onRequestClose={() => setShowTimezonePicker(false)}
+                    >
+                      <Pressable
+                        className="flex-1 justify-center items-center bg-black/50"
+                        onPress={() => setShowTimezonePicker(false)}
+                      >
+                        <Pressable
+                          className="overflow-hidden w-80 max-h-96 bg-white rounded-2xl"
+                          onPress={(e) => e.stopPropagation()}
+                        >
+                          <View className="px-4 py-3 border-b border-gray-200">
+                            <Text className="text-lg font-semibold text-center text-gray-800">
+                              Select Timezone
+                            </Text>
+                          </View>
+                          <RNScrollView className="max-h-80">
+                            {TIMEZONES.map((tz) => (
+                              <TouchableOpacity
+                                key={tz.value}
+                                className={`px-4 py-3 ${value === tz.value ? 'bg-[#3B82F6]' : 'bg-white'}`}
+                                onPress={() => {
+                                  onChange(tz.value);
+                                  setShowTimezonePicker(false);
+                                }}
+                                testID={`timezone-option-${tz.value}`}
+                              >
+                                <Text
+                                  className={`text-base ${value === tz.value ? 'text-white font-semibold' : 'text-gray-800'}`}
+                                >
+                                  {tz.label}
+                                </Text>
+                              </TouchableOpacity>
+                            ))}
+                          </RNScrollView>
+                        </Pressable>
+                      </Pressable>
+                    </Modal>
+                  </>
+                )}
+              />
             </View>
           </View>
 
@@ -168,35 +275,59 @@ export default function ProfileEditForm({ profile, isLoading, onCancel, onSucces
 
             <View className="bg-[#2B42B6] rounded-2xl p-5 mb-4 shadow-md border border-[#33CFFF]" style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}>
               <Text className="text-[#708090] text-sm font-medium mb-1">Desires</Text>
-              <TextInput
-                className="bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-4"
-                value={formData.desires}
-                onChangeText={(value) => handleInputChange('desires', value)}
-                placeholder="What do you desire to achieve?"
-                placeholderTextColor="#708090"
-                multiline
-                numberOfLines={3}
-                testID="profile-edit-desires"
+              <Controller
+                control={control}
+                name="desires"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className={inputClassName}
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="What do you desire to achieve?"
+                    placeholderTextColor="#708090"
+                    multiline
+                    numberOfLines={3}
+                    testID="profile-edit-desires"
+                  />
+                )}
               />
+              {errors.desires && (
+                <Text className={fieldErrorClassName} testID="profile-edit-desires-error">
+                  {errors.desires.message}
+                </Text>
+              )}
 
-              <Text className="text-[#708090] text-sm font-medium mb-1">Limiting Beliefs</Text>
-              <TextInput
-                className="bg-[#1A2B5C] rounded-xl p-3 text-[#F1F5F9] text-base mb-4"
-                value={formData.limiting_beliefs}
-                onChangeText={(value) => handleInputChange('limiting_beliefs', value)}
-                placeholder="What beliefs might be holding you back?"
-                placeholderTextColor="#708090"
-                multiline
-                numberOfLines={3}
-                testID="profile-edit-limiting-beliefs"
+              <Text className="text-[#708090] text-sm font-medium mb-1 mt-3">Limiting Beliefs</Text>
+              <Controller
+                control={control}
+                name="limiting_beliefs"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className={inputClassName}
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    placeholder="What beliefs might be holding you back?"
+                    placeholderTextColor="#708090"
+                    multiline
+                    numberOfLines={3}
+                    testID="profile-edit-limiting-beliefs"
+                  />
+                )}
               />
+              {errors.limiting_beliefs && (
+                <Text className={fieldErrorClassName} testID="profile-edit-limiting-beliefs-error">
+                  {errors.limiting_beliefs.message}
+                </Text>
+              )}
             </View>
           </View>
 
           <View className="gap-4">
             <PrimaryButton
               title='Save Changes'
-              onPress={() => onSuccess(formData)}
+              onPress={handleSubmit(onSubmit)}
               isLoading={isLoading}
               loadingText='Saving...'
               testID='profile-edit-save-button'
@@ -211,46 +342,6 @@ export default function ProfileEditForm({ profile, isLoading, onCancel, onSucces
           </View>
         </ScrollView>
       </KeyboardAvoidingView>
-
-      {/* Timezone Picker Modal */}
-      <Modal
-        visible={showTimezonePicker}
-        transparent
-        animationType="fade"
-        onRequestClose={() => setShowTimezonePicker(false)}
-      >
-        <Pressable
-          className="flex-1 justify-center items-center bg-black/50"
-          onPress={() => setShowTimezonePicker(false)}
-        >
-          <Pressable
-            className="overflow-hidden w-80 max-h-96 bg-white rounded-2xl"
-            onPress={(e) => e.stopPropagation()}
-          >
-            <View className="px-4 py-3 border-b border-gray-200">
-              <Text className="text-lg font-semibold text-center text-gray-800">
-                Select Timezone
-              </Text>
-            </View>
-            <RNScrollView className="max-h-80">
-              {TIMEZONES.map((tz) => (
-                <TouchableOpacity
-                  key={tz.value}
-                  className={`px-4 py-3 ${formData.timezone === tz.value ? 'bg-[#3B82F6]' : 'bg-white'}`}
-                  onPress={() => handleTimezoneSelect(tz.value)}
-                  testID={`timezone-option-${tz.value}`}
-                >
-                  <Text
-                    className={`text-base ${formData.timezone === tz.value ? 'text-white font-semibold' : 'text-gray-800'}`}
-                  >
-                    {tz.label}
-                  </Text>
-                </TouchableOpacity>
-              ))}
-            </RNScrollView>
-          </Pressable>
-        </Pressable>
-      </Modal>
     </LinearGradient>
   );
 }

--- a/hooks/useGoalCreation.ts
+++ b/hooks/useGoalCreation.ts
@@ -3,26 +3,21 @@ import { useState } from 'react';
 import { useToast } from '../components/ToastManager';
 import {
   formatTimeframeForAiResponse,
-  getServerTimeframe,
-  validateGoalData
+  getServerTimeframe
 } from '../utils/smartGoalFormatters';
 import { useAiProxy } from './useAiProxy';
 import { useCreateSmartGoal } from './useSmartGoals';
 
 export interface GoalCreationState {
-  goalDescription: string;
-  selectedTimeframe: string;
   showConfirmation: boolean;
   isLoading: boolean;
   aiResponse: any;
 }
 
 export interface GoalCreationActions {
-  setGoalDescription: (description: string) => void;
-  setSelectedTimeframe: (timeframe: string) => void;
   setShowConfirmation: (show: boolean) => void;
-  handleCreateGoal: () => Promise<void>;
-  handleConfirmGoal: () => Promise<void>;
+  handleCreateGoal: (description: string, timeframe: string) => Promise<void>;
+  handleConfirmGoal: (description: string, timeframe: string) => Promise<void>;
   handleEditGoal: () => void;
   handleCancel: () => void;
 }
@@ -32,37 +27,29 @@ export const useGoalCreation = (): GoalCreationActions & GoalCreationState => {
   const { processAiRequest, isLoading, aiResponse } = useAiProxy();
   const toast = useToast();
 
-  const [goalDescription, setGoalDescription] = useState('');
-  const [selectedTimeframe, setSelectedTimeframe] = useState('');
   const [showConfirmation, setShowConfirmation] = useState(false);
 
-  const handleCreateGoal = async (): Promise<void> => {
-    const validation = validateGoalData(goalDescription, selectedTimeframe);
-    if (!validation.isValid) {
-      toast.error(validation.errorMessage ?? 'Invalid goal data');
-      return;
-    }
-
+  const handleCreateGoal = async (description: string, timeframe: string): Promise<void> => {
     try {
-      await processAiRequest(goalDescription, selectedTimeframe);
+      await processAiRequest(description, timeframe);
       setShowConfirmation(true);
     } catch {
       // apiRequest interceptor surfaces the error toast
     }
   };
 
-  const handleConfirmGoal = async (): Promise<void> => {
+  const handleConfirmGoal = async (description: string, timeframe: string): Promise<void> => {
     try {
       if (!aiResponse) {
         throw new Error('No goal details available');
       }
 
-      const formattedResponse = formatTimeframeForAiResponse(selectedTimeframe, aiResponse);
-      const serverTimeframe = getServerTimeframe(selectedTimeframe);
+      const formattedResponse = formatTimeframeForAiResponse(timeframe, aiResponse);
+      const serverTimeframe = getServerTimeframe(timeframe);
 
       await createSmartGoal({
         title: formattedResponse.specific,
-        description: goalDescription,
+        description,
         timeframe: serverTimeframe,
         specific: formattedResponse.specific,
         measurable: formattedResponse.measurable,
@@ -94,16 +81,9 @@ export const useGoalCreation = (): GoalCreationActions & GoalCreationState => {
   };
 
   return {
-    // State
-    goalDescription,
-    selectedTimeframe,
     showConfirmation,
     isLoading,
     aiResponse,
-    
-    // Actions
-    setGoalDescription,
-    setSelectedTimeframe,
     setShowConfirmation,
     handleCreateGoal,
     handleConfirmGoal,

--- a/models/auth.ts
+++ b/models/auth.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const emailSchema = z
+  .string()
+  .trim()
+  .min(1, 'Email is required')
+  .email('Enter a valid email');
+
+export const passwordSchema = z
+  .string()
+  .min(6, 'Password must be at least 6 characters')
+  .max(128, 'Password is too long');
+
+export const userSchema = z.object({
+  id: z.number().int().positive(),
+  email: emailSchema,
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type UserModel = z.infer<typeof userSchema>;

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,0 +1,4 @@
+export * from './auth';
+export * from './profile';
+export * from './smartGoal';
+export * from './task';

--- a/models/profile.ts
+++ b/models/profile.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+export const onboardingStatusSchema = z.enum(['incomplete', 'complete']);
+
+export const profileSchema = z.object({
+  id: z.number().int().positive(),
+  user_id: z.number().int().positive(),
+  first_name: z.string().trim().max(100).optional(),
+  last_name: z.string().trim().max(100).optional(),
+  work_role: z.string().trim().max(200).optional(),
+  education: z.string().trim().max(200).optional(),
+  desires: z.string().trim().max(2000).optional(),
+  limiting_beliefs: z.string().trim().max(2000).optional(),
+  timezone: z.string().trim().max(64).optional(),
+  onboarding_status: onboardingStatusSchema,
+  onboarding_completed_at: z.string().optional(),
+  created_at: z.string(),
+  updated_at: z.string(),
+});
+
+export type ProfileModel = z.infer<typeof profileSchema>;

--- a/models/smartGoal.ts
+++ b/models/smartGoal.ts
@@ -1,0 +1,23 @@
+import { z } from 'zod';
+
+export const timeframeSchema = z.enum(['1_month', '3_months', '6_months']);
+
+export const smartGoalSchema = z.object({
+  id: z.number().int().positive().optional(),
+  profile_id: z.number().int().positive(),
+  title: z.string().trim().min(1, 'Title is required').max(200),
+  description: z.string().trim().max(2000).optional(),
+  timeframe: timeframeSchema,
+  specific: z.string().trim().min(1),
+  measurable: z.string().trim().min(1),
+  achievable: z.string().trim().min(1),
+  relevant: z.string().trim().min(1),
+  time_bound: z.string().trim().min(1),
+  completed: z.boolean(),
+  target_date: z.string().optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export type SmartGoalModel = z.infer<typeof smartGoalSchema>;
+export type Timeframe = z.infer<typeof timeframeSchema>;

--- a/models/task.ts
+++ b/models/task.ts
@@ -1,0 +1,20 @@
+import { z } from 'zod';
+
+export const taskActionCategorySchema = z.enum(['do', 'defer', 'delegate']);
+
+export const taskPrioritySchema = z.number().int().min(1).max(3);
+
+export const taskSchema = z.object({
+  id: z.number().int().positive().optional(),
+  profile_id: z.number().int().positive(),
+  title: z.string().trim().min(1, 'Title is required').max(200, 'Title is too long'),
+  description: z.string().trim().max(2000).optional(),
+  completed: z.boolean(),
+  action_category: taskActionCategorySchema,
+  priority: taskPrioritySchema.optional(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export type TaskModel = z.infer<typeof taskSchema>;
+export type TaskActionCategory = z.infer<typeof taskActionCategorySchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@expo/ngrok": "^4.1.0",
         "@expo/vector-icons": "^15.0.3",
+        "@hookform/resolvers": "^5.2.2",
         "@react-native-async-storage/async-storage": "^2.2.0",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
@@ -37,6 +38,7 @@
         "nativewind": "^4.1.23",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "react-hook-form": "^7.75.0",
         "react-native": "0.81.5",
         "react-native-gesture-handler": "~2.28.0",
         "react-native-reanimated": "~4.1.1",
@@ -44,7 +46,8 @@
         "react-native-screens": "~4.16.0",
         "react-native-web": "^0.21.0",
         "react-native-webview": "13.15.0",
-        "react-native-worklets": "0.5.1"
+        "react-native-worklets": "0.5.1",
+        "zod": "^4.4.3"
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
@@ -2953,6 +2956,18 @@
         "@babel/highlight": "^7.10.4"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -4749,6 +4764,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@szmarczak/http-timer": {
       "version": "4.0.6",
@@ -15415,6 +15436,22 @@
         "react": ">=17.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.75.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.75.0.tgz",
+      "integrity": "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-19.1.1.tgz",
@@ -19029,6 +19066,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "@expo/ngrok": "^4.1.0",
     "@expo/vector-icons": "^15.0.3",
+    "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^2.2.0",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
@@ -45,6 +46,7 @@
     "nativewind": "^4.1.23",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "react-hook-form": "^7.75.0",
     "react-native": "0.81.5",
     "react-native-gesture-handler": "~2.28.0",
     "react-native-reanimated": "~4.1.1",
@@ -52,7 +54,8 @@
     "react-native-screens": "~4.16.0",
     "react-native-web": "^0.21.0",
     "react-native-webview": "13.15.0",
-    "react-native-worklets": "0.5.1"
+    "react-native-worklets": "0.5.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/utils/reportError.ts
+++ b/utils/reportError.ts
@@ -1,0 +1,14 @@
+type ErrorContext = Record<string, unknown>;
+
+export function reportError(error: unknown, context?: ErrorContext) {
+  console.error('[reportError]', error, context);
+
+  const sentry = (globalThis as { Sentry?: { captureException?: (err: unknown, ctx?: unknown) => void } }).Sentry;
+  if (sentry?.captureException) {
+    try {
+      sentry.captureException(error, context ? { extra: context } : undefined);
+    } catch (e) {
+      console.error('[reportError] Sentry capture failed', e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Lands PC-F2 (form validation) and PC-F3 (error boundaries) — the two sub-tickets of PC-F (Frontend Reliability Foundations) that PC-F1 (toast system) didn't already cover. Every form in the app now goes through `react-hook-form` + `zod` with inline per-field validation, and high-risk screens are wrapped in a recoverable `ErrorBoundary` with a retry CTA.

Canonical domain schemas live in a new top-level `models/` directory (one file per resource: profile, task, smartGoal, auth). Form schemas live next to each form and are derived from the model via `.pick()` / `.omit()` / `.extend()` — keeping the shared truth in `models/` while letting forms diverge on requiredness and form-only fields. Server errors continue to flow through the PC-F1 toast interceptor; nothing duplicates the auto-error toast.

### Why

Trial users don't report bugs — they leave. Silent failure and white screens are the single most common churn cause during evaluation, per the parent ticket. Inline validation prevents bad submits from reaching the server, and the boundary keeps a screen crash recoverable in two taps instead of fatal.

## Changes

- `package.json`, `package-lock.json`
  - Add `react-hook-form`, `zod`, `@hookform/resolvers`.
- `models/{auth,profile,smartGoal,task,index}.ts`
  - Canonical zod schemas, one per domain resource.
- `components/ErrorBoundary.tsx`, `utils/reportError.ts`
  - Class-based boundary with `onReset` / `onError` / `scope` props and a default fallback (icon + message + retry button). Reporter is the single hook point for future error reporting (Sentry, etc.) — today it just logs to console.
- `app/(tabs)/_layout.tsx`, `app/smartGoals/index.tsx`, `app/onboarding.tsx`
  - Wrap-only: no form work in these files. `onReset` on the smart goals boundary invalidates the `['smartGoals']` query.
- `app/taskDetail/[id].tsx`
  - Migrate the edit form to RHF + zod and wrap the screen in an `ErrorBoundary` whose `onReset` invalidates the `['tasks']` query.
- `app/addGoal/index.tsx`
  - Migrate the goal-creation form to RHF + zod and wrap the screen.
- `app/addTask/index.tsx`, `components/ProfileEditForm.tsx`
  - Migrate to RHF + zod with `Controller` wrappers and inline error rendering.
- `hooks/useGoalCreation.ts`
  - Refactor: hook no longer owns `goalDescription` / `selectedTimeframe` state. Submitters accept values as args so the screen-level form can drive them.
- `components/AiOnboardingWizard.tsx`, `components/AiOnboardingWizardSteps.tsx`
  - Wizard exposes `onboardingProfileSchema` / `onboardingGoalSchema` derived from `profileSchema`. ProfileDetailsStep and GoalDescriptionStep each own an RHF form; wizard owns flow state and holds the submitted description across steps.
- `app/auth/{login,signup,forgot-password,password-reset-confirm}.tsx`
  - Migrate each to RHF + zod using the shared `emailSchema` / `passwordSchema` building blocks from `models/auth.ts`. Signup and password-reset-confirm use `.refine` for password-match.
- `__tests__/screens/{AddTask,Login,Signup,ForgotPassword,PasswordResetConfirm}Screen.test.tsx`, `__tests__/hooks/useGoalCreation.test.tsx`
  - Updated to assert the new behavior: submit button disabled while invalid, inline `*-error` testIDs in place of the old toast-based validation errors, and `await waitFor(...)` on the button enabling before pressing (zodResolver is async).
- `README.md`
  - New "Forms" and "Error boundaries" sections documenting the conventions (models vs. form schemas, `Controller` pattern, `mode: 'onChange'`, `onReset` should refetch, `scope` always set).

## Test Plan

- [x] `npx tsc --noEmit` — clean.
- [x] `npx expo lint` — clean.
- [x] `npx jest --ci` — 376/376 passing across 39 suites.
- [ ] Manual: try submitting each migrated form with invalid input (empty, too short, bad email, mismatched passwords) and confirm the inline error renders and the submit button stays disabled.
- [ ] Manual: trigger a render error inside one wrapped screen (e.g. throw in a useEffect) and verify the fallback shows + Retry recovers the screen and refetches the underlying query.

## Additional Notes

- **Out of scope:** auth forms weren't in the original PC-F2 ticket text ("onboarding, task/goal create-edit, profile") but were added at request — same convention, same models.
- **Goal edit form** doesn't exist in the app yet, so only goal create is migrated.
- **"Goal detail" screen** doesn't exist either — the smart goals *list* screen is wrapped in its place, since that's where the wizard is mounted from.
- The four password-related auth forms surface pre-existing nativewind `cssConflict` warnings on `text-* placeholder:text-*` classNames — not introduced here.