### PR TITLE
feat: goal ↔ task connection UX (PC-B1, PC-B2, PC-B3)

### DIFF
--- a/.eas/workflows/deploy-to-production.yml
+++ b/.eas/workflows/deploy-to-production.yml
@@ -5,64 +5,49 @@ on:
     branches: ["main"]
 
 jobs:
-  # fingerprint:
-  #   name: Fingerprint
-  #   type: fingerprint
-  #   environment: production
-  # get_android_build:
-  #   name: Check for existing android build
-  #   needs: [fingerprint]
-  #   type: get-build
-  #   params:
-  #     fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
-  #     profile: production
-  # get_ios_build:
-  #   name: Check for existing ios build
-  #   needs: [fingerprint]
-  #   type: get-build
-  #   params:
-  #     fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
-  #     profile: production
-  # build_android:
-  #   name: Build Android
-  #   needs: [get_android_build]
-  #   if: ${{ !needs.get_android_build.outputs.build_id }}
-  #   type: build
-  #   params:
-  #     platform: android
-  #     profile: production
+  fingerprint:
+    name: Fingerprint
+    type: fingerprint
+    environment: production
+
+  get_ios_build:
+    name: Check for existing ios build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.ios_fingerprint_hash }}
+      profile: production
+
   build_ios:
     name: Build iOS
+    needs: [get_ios_build]
+    if: ${{ !needs.get_ios_build.outputs.build_id }}
     type: build
     params:
       platform: ios
       profile: production
-  # submit_android_build:
-  #   name: Submit Android Build
-  #   needs: [build_android]
-  #   type: submit
-  #   params:
-  #     build_id: ${{ needs.build_android.outputs.build_id }}
-  submit_ios_build:
-    name: Submit iOS Build
+
+  submit_ios_existing_build:
+    name: Submit matching iOS build
+    needs: [get_ios_build]
+    if: ${{ needs.get_ios_build.outputs.build_id }}
+    type: submit
+    params:
+      build_id: ${{ needs.get_ios_build.outputs.build_id }}
+
+  submit_ios_new_build:
+    name: Submit new iOS build
     needs: [build_ios]
     if: ${{ needs.build_ios.outputs.build_id }}
     type: submit
     params:
       build_id: ${{ needs.build_ios.outputs.build_id }}
-  # publish_android_update:
-  #   name: Publish Android update
-  #   needs: [get_android_build]
-  #   if: ${{ needs.get_android_build.outputs.build_id }}
-  #   type: update
-  #   params:
-  #     branch: production
-  #     platform: android
-  publish_ios_update:
-    name: Publish iOS update
-    needs: [build_ios]
-    if: ${{ needs.build_ios.outputs.build_id }}
+
+  publish_ios_preview_update:
+    name: Publish iOS preview update
+    needs: [get_ios_build, build_ios]
+    if: ${{ needs.get_ios_build.outputs.build_id || needs.build_ios.outputs.build_id }}
     type: update
     params:
-      branch: production
+      branch: preview
       platform: ios

--- a/__tests__/screens/AddTaskScreen.test.tsx
+++ b/__tests__/screens/AddTaskScreen.test.tsx
@@ -6,9 +6,13 @@ import AddTaskScreen from '../../app/addTask';
 
 // Mock the API module
 jest.mock('../../api/tasks');
+jest.mock('../../hooks/useSmartGoals', () => ({
+  useSmartGoals: jest.fn(),
+}));
 
 // Mock expo-router
 jest.mock('expo-router', () => ({
+  useLocalSearchParams: jest.fn(() => ({})),
   useRouter: () => ({
     push: jest.fn(),
     back: jest.fn(),
@@ -17,7 +21,6 @@ jest.mock('expo-router', () => ({
     push: jest.fn(),
     back: jest.fn(),
   },
-  useLocalSearchParams: () => ({}),
 }));
 
 // Mock Alert
@@ -30,6 +33,8 @@ jest.mock('@tanstack/react-query', () => ({
 }));
 
 const mockUseMutation = require('@tanstack/react-query').useMutation;
+const mockUseLocalSearchParams = require('expo-router').useLocalSearchParams;
+const mockUseSmartGoals = require('../../hooks/useSmartGoals').useSmartGoals;
 
 describe('AddTaskScreen', () => {
   let queryClient: QueryClient;
@@ -44,6 +49,12 @@ describe('AddTaskScreen', () => {
 
     // Reset all mocks
     jest.clearAllMocks();
+    mockUseLocalSearchParams.mockReturnValue({});
+    mockUseSmartGoals.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('renders form fields', () => {
@@ -107,7 +118,97 @@ describe('AddTaskScreen', () => {
           action_category: 'do',
           completed: false,
           priority: 1,
+          smart_goal_id: null,
         },
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+        })
+      );
+    });
+  });
+
+  it('passes smart_goal_id when navigating from a smart goal', async () => {
+    const mockMutate = jest.fn();
+    mockUseLocalSearchParams.mockReturnValue({ smartGoalId: '42' });
+
+    mockUseMutation.mockReturnValue({
+      mutate: mockMutate,
+      isLoading: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      reset: jest.fn(),
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AddTaskScreen />
+      </QueryClientProvider>
+    );
+
+    const titleInput = screen.getByTestId('add-task-task-name-input');
+    const submitButton = screen.getByTestId('add-task-add-button');
+
+    fireEvent.changeText(titleInput, 'Task for goal');
+
+    await waitFor(() => {
+      expect(submitButton.props.accessibilityState?.disabled).toBe(false);
+    });
+
+    fireEvent.press(submitButton);
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Task for goal',
+          smart_goal_id: 42,
+        }),
+        expect.objectContaining({
+          onSuccess: expect.any(Function),
+        })
+      );
+    });
+  });
+
+  it('allows selecting a goal and submits smart_goal_id', async () => {
+    const mockMutate = jest.fn();
+    mockUseSmartGoals.mockReturnValue({
+      data: [{ id: 7, title: 'Run a 5k', profile_id: 1, timeframe: '1_month', specific: '', measurable: '', achievable: '', relevant: '', time_bound: '', completed: false }],
+      isLoading: false,
+      error: null,
+    });
+
+    mockUseMutation.mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+      isError: false,
+      isSuccess: false,
+      error: null,
+      reset: jest.fn(),
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <AddTaskScreen />
+      </QueryClientProvider>
+    );
+
+    const submitButton = screen.getByTestId('add-task-add-button');
+    fireEvent.press(screen.getByTestId('add-task-goal-option-7'));
+    fireEvent.changeText(screen.getByTestId('add-task-task-name-input'), 'Linked task');
+
+    await waitFor(() => {
+      expect(submitButton.props.accessibilityState?.disabled).toBe(false);
+    });
+
+    fireEvent.press(submitButton);
+
+    await waitFor(() => {
+      expect(mockMutate).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Linked task',
+          smart_goal_id: 7,
+        }),
         expect.objectContaining({
           onSuccess: expect.any(Function),
         })

--- a/__tests__/screens/TaskDetailScreen.test.tsx
+++ b/__tests__/screens/TaskDetailScreen.test.tsx
@@ -36,10 +36,14 @@ jest.mock('../../hooks/useTasks', () => ({
   useUpdateTask: jest.fn(),
   useDeleteTask: jest.fn(),
 }));
+jest.mock('../../hooks/useSmartGoals', () => ({
+  useSmartGoal: jest.fn(),
+}));
 
 const mockUseTask = require('../../hooks/useTasks').useTask;
 const mockUseUpdateTask = require('../../hooks/useTasks').useUpdateTask;
 const mockUseDeleteTask = require('../../hooks/useTasks').useDeleteTask;
+const mockUseSmartGoal = require('../../hooks/useSmartGoals').useSmartGoal;
 
 describe('TaskDetailScreen', () => {
   let queryClient: QueryClient;
@@ -54,6 +58,11 @@ describe('TaskDetailScreen', () => {
 
     // Reset all mocks
     jest.clearAllMocks();
+    mockUseSmartGoal.mockReturnValue({
+      data: null,
+      isLoading: false,
+      error: null,
+    });
   });
 
   it('renders loading state', () => {
@@ -398,6 +407,78 @@ describe('TaskDetailScreen', () => {
     );
 
     expect(screen.getByTestId('task-detail-status')).toBeTruthy();
+  });
+
+  it('shows linked goal section when task has smart_goal_id', () => {
+    const mockTask = {
+      id: 1,
+      title: 'Task with goal',
+      description: 'Linked',
+      completed: false,
+      action_category: 'do' as const,
+      smart_goal_id: 12,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    mockUseTask.mockReturnValue({
+      data: mockTask,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+      isFetching: false,
+      isRefetching: false,
+      refetch: jest.fn(),
+    });
+    mockUseUpdateTask.mockReturnValue({ mutate: jest.fn(), isPending: false, isError: false, isSuccess: false, error: null, reset: jest.fn() });
+    mockUseDeleteTask.mockReturnValue({ mutate: jest.fn(), isPending: false, isError: false, isSuccess: false, error: null, reset: jest.fn() });
+    mockUseSmartGoal.mockReturnValue({
+      data: { id: 12, title: 'Complete Marathon Plan' },
+      isLoading: false,
+      error: null,
+    });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TaskDetailScreen />
+      </QueryClientProvider>
+    );
+
+    expect(screen.getByTestId('task-detail-linked-goal-section')).toBeTruthy();
+    expect(screen.getByTestId('task-detail-linked-goal-title')).toBeTruthy();
+  });
+
+  it('hides linked goal section when task has no smart_goal_id', () => {
+    const mockTask = {
+      id: 1,
+      title: 'Task without goal',
+      description: 'Not linked',
+      completed: false,
+      action_category: 'do' as const,
+      smart_goal_id: null,
+      created_at: '2024-01-01T00:00:00Z',
+    };
+
+    mockUseTask.mockReturnValue({
+      data: mockTask,
+      isLoading: false,
+      error: null,
+      isError: false,
+      isSuccess: true,
+      isFetching: false,
+      isRefetching: false,
+      refetch: jest.fn(),
+    });
+    mockUseUpdateTask.mockReturnValue({ mutate: jest.fn(), isPending: false, isError: false, isSuccess: false, error: null, reset: jest.fn() });
+    mockUseDeleteTask.mockReturnValue({ mutate: jest.fn(), isPending: false, isError: false, isSuccess: false, error: null, reset: jest.fn() });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <TaskDetailScreen />
+      </QueryClientProvider>
+    );
+
+    expect(screen.queryByTestId('task-detail-linked-goal-section')).toBeNull();
   });
 
   it('refetches task after successful mutation', async () => {

--- a/__tests__/screens/TaskDetailScreen.test.tsx
+++ b/__tests__/screens/TaskDetailScreen.test.tsx
@@ -38,12 +38,14 @@ jest.mock('../../hooks/useTasks', () => ({
 }));
 jest.mock('../../hooks/useSmartGoals', () => ({
   useSmartGoal: jest.fn(),
+  useSmartGoals: jest.fn(),
 }));
 
 const mockUseTask = require('../../hooks/useTasks').useTask;
 const mockUseUpdateTask = require('../../hooks/useTasks').useUpdateTask;
 const mockUseDeleteTask = require('../../hooks/useTasks').useDeleteTask;
 const mockUseSmartGoal = require('../../hooks/useSmartGoals').useSmartGoal;
+const mockUseSmartGoals = require('../../hooks/useSmartGoals').useSmartGoals;
 
 describe('TaskDetailScreen', () => {
   let queryClient: QueryClient;
@@ -60,6 +62,11 @@ describe('TaskDetailScreen', () => {
     jest.clearAllMocks();
     mockUseSmartGoal.mockReturnValue({
       data: null,
+      isLoading: false,
+      error: null,
+    });
+    mockUseSmartGoals.mockReturnValue({
+      data: [],
       isLoading: false,
       error: null,
     });

--- a/api/smartGoals.ts
+++ b/api/smartGoals.ts
@@ -1,5 +1,13 @@
 // API client for Rails server smart goals endpoints
 import { apiDelete, apiGet, apiPatch, apiPost, type ApiResponse } from '../utils/apiRequest';
+import type { Task } from './tasks';
+
+export interface SmartGoalDetail extends SmartGoal {
+  tasks: {
+    open: Task[];
+    completed: Task[];
+  };
+}
 
 export interface SmartGoal {
   id?: number;
@@ -50,8 +58,8 @@ export class SmartGoalsAPI {
     return apiGet<SmartGoal[]>('/smart_goals');
   }
 
-  async getSmartGoal(id: number): Promise<ApiResponse<SmartGoal>> {
-    return apiGet<SmartGoal>(`/smart_goals/${id}`);
+  async getSmartGoal(id: number): Promise<ApiResponse<SmartGoalDetail>> {
+    return apiGet<SmartGoalDetail>(`/smart_goals/${id}`);
   }
 
   async createSmartGoal(data: CreateSmartGoalParams): Promise<ApiResponse<SmartGoal>> {

--- a/api/tasks.ts
+++ b/api/tasks.ts
@@ -10,6 +10,8 @@ export interface Task {
   action_category: 'do' | 'defer' | 'delegate';
   priority?: number;
   profile_id: number;
+  smart_goal_id?: number | null;
+  due_at?: string | null;
   created_at?: string;
   updated_at?: string;
   isAiSuggestion?: boolean;
@@ -22,6 +24,8 @@ export interface CreateTaskParams {
   completed?: boolean;
   priority?: number;
   action_category: 'do' | 'defer' | 'delegate';
+  smart_goal_id?: number | null;
+  due_at?: string | null;
 }
 
 // Update task parameters (all fields optional except id)
@@ -31,6 +35,8 @@ export interface UpdateTaskParams {
   completed?: boolean;
   priority?: number;
   action_category?: 'do' | 'defer' | 'delegate';
+  smart_goal_id?: number | null;
+  due_at?: string | null;
 }
 
 // Tasks API class

--- a/api/tasks.ts
+++ b/api/tasks.ts
@@ -11,6 +11,7 @@ export interface Task {
   priority?: number;
   profile_id: number;
   smart_goal_id?: number | null;
+  smart_goal?: { id: number; title: string } | null;
   due_at?: string | null;
   created_at?: string;
   updated_at?: string;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -93,6 +93,13 @@ function AppContent() {
                   headerBackTitle: "Menu"
                 }} />
               <Stack.Screen
+                name="smartGoals/[id]"
+                options={{
+                  headerShown: true,
+                  headerTitle: "Goal Details",
+                  headerBackTitle: "Goals"
+                }} />
+              <Stack.Screen
                 name="taskDetail/[id]"
                 options={{
                   headerShown: true,

--- a/app/addTask/index.tsx
+++ b/app/addTask/index.tsx
@@ -4,11 +4,12 @@ import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { PriorityInput } from '@/components/inputs';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
+import { useSmartGoals } from '@/hooks/useSmartGoals';
 import { useCreateTask } from '@/hooks/useTasks';
 import { taskSchema } from '@/models';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { router } from 'expo-router';
-import React from 'react';
+import { router, useLocalSearchParams } from 'expo-router';
+import React, { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
 import { z } from 'zod';
@@ -34,6 +35,12 @@ export default function AddTaskScreen() {
 
 function AddTaskContent() {
   const createTaskMutation = useCreateTask();
+  const { data: smartGoals = [], isLoading: isLoadingSmartGoals } = useSmartGoals();
+
+  const { smartGoalId } = useLocalSearchParams<{ smartGoalId?: string }>();
+  const parsedSmartGoalId = parseInt(smartGoalId || '', 10)
+
+  const [selectedSmartGoalId, setSelectedSmartGoalId] = useState<number | null>(parsedSmartGoalId);
 
   const { control, handleSubmit, formState: { errors, isValid } } = useForm<AddTaskFormValues>({
     resolver: zodResolver(addTaskFormSchema),
@@ -53,6 +60,7 @@ function AddTaskContent() {
       priority: values.priority,
       action_category: values.action_category,
       completed: false,
+      smart_goal_id: selectedSmartGoalId,
     };
 
     createTaskMutation.mutate(newTask, {
@@ -170,6 +178,58 @@ function AddTaskContent() {
                   </View>
                 )}
               />
+            </View>
+
+            <View className="mb-5" testID="add-task-goal-linking-section">
+              <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Linked Goal (optional):</Text>
+              {isLoadingSmartGoals ? (
+                <Text className="text-[#708090] text-sm" testID="add-task-goal-loading">
+                  Loading goals...
+                </Text>
+              ) : (
+                <View className="gap-2">
+                  <Pressable
+                    onPress={() => setSelectedSmartGoalId(null)}
+                    className={`py-3 px-4 rounded-lg border ${selectedSmartGoalId === null
+                      ? 'border-cyan-400 bg-cyan-400'
+                      : 'border-[#708090] bg-[#13203a]'
+                      }`}
+                    disabled={createTaskMutation.isPending}
+                    testID="add-task-goal-option-none"
+                  >
+                    <Text
+                      className={`font-medium ${selectedSmartGoalId === null
+                        ? 'text-[#021A40]'
+                        : 'text-[#E6FAFF]'
+                        }`}
+                    >
+                      None
+                    </Text>
+                  </Pressable>
+
+                  {smartGoals.map(goal => (
+                    <Pressable
+                      key={goal.id}
+                      onPress={() => setSelectedSmartGoalId(goal.id ?? null)}
+                      className={`py-3 px-4 rounded-lg border ${selectedSmartGoalId === goal.id
+                        ? 'border-cyan-400 bg-cyan-400'
+                        : 'border-[#708090] bg-[#13203a]'
+                        }`}
+                      disabled={createTaskMutation.isPending}
+                      testID={`add-task-goal-option-${goal.id}`}
+                    >
+                      <Text
+                        className={`font-medium ${selectedSmartGoalId === goal.id
+                          ? 'text-[#021A40]'
+                          : 'text-[#E6FAFF]'
+                          }`}
+                      >
+                        {goal.title}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+              )}
             </View>
 
             <View className="gap-4">

--- a/app/addTask/index.tsx
+++ b/app/addTask/index.tsx
@@ -1,6 +1,7 @@
 import { CreateTaskParams } from '@/api/tasks';
 import { PrimaryButton, SecondaryButton } from '@/components/buttons/';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { LinkedGoalSelector } from '@/components/goals/LinkedGoalSelector';
 import { PriorityInput } from '@/components/inputs';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
@@ -38,9 +39,10 @@ function AddTaskContent() {
   const { data: smartGoals = [], isLoading: isLoadingSmartGoals } = useSmartGoals();
 
   const { smartGoalId } = useLocalSearchParams<{ smartGoalId?: string }>();
-  const parsedSmartGoalId = parseInt(smartGoalId || '', 10)
+  const parsedSmartGoalId = parseInt(smartGoalId || '', 10);
+  const initialSmartGoalId = Number.isInteger(parsedSmartGoalId) && parsedSmartGoalId > 0 ? parsedSmartGoalId : null;
 
-  const [selectedSmartGoalId, setSelectedSmartGoalId] = useState<number | null>(parsedSmartGoalId);
+  const [selectedSmartGoalId, setSelectedSmartGoalId] = useState<number | null>(initialSmartGoalId);
 
   const { control, handleSubmit, formState: { errors, isValid } } = useForm<AddTaskFormValues>({
     resolver: zodResolver(addTaskFormSchema),
@@ -180,57 +182,13 @@ function AddTaskContent() {
               />
             </View>
 
-            <View className="mb-5" testID="add-task-goal-linking-section">
-              <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Linked Goal (optional):</Text>
-              {isLoadingSmartGoals ? (
-                <Text className="text-[#708090] text-sm" testID="add-task-goal-loading">
-                  Loading goals...
-                </Text>
-              ) : (
-                <View className="gap-2">
-                  <Pressable
-                    onPress={() => setSelectedSmartGoalId(null)}
-                    className={`py-3 px-4 rounded-lg border ${selectedSmartGoalId === null
-                      ? 'border-cyan-400 bg-cyan-400'
-                      : 'border-[#708090] bg-[#13203a]'
-                      }`}
-                    disabled={createTaskMutation.isPending}
-                    testID="add-task-goal-option-none"
-                  >
-                    <Text
-                      className={`font-medium ${selectedSmartGoalId === null
-                        ? 'text-[#021A40]'
-                        : 'text-[#E6FAFF]'
-                        }`}
-                    >
-                      None
-                    </Text>
-                  </Pressable>
-
-                  {smartGoals.map(goal => (
-                    <Pressable
-                      key={goal.id}
-                      onPress={() => setSelectedSmartGoalId(goal.id ?? null)}
-                      className={`py-3 px-4 rounded-lg border ${selectedSmartGoalId === goal.id
-                        ? 'border-cyan-400 bg-cyan-400'
-                        : 'border-[#708090] bg-[#13203a]'
-                        }`}
-                      disabled={createTaskMutation.isPending}
-                      testID={`add-task-goal-option-${goal.id}`}
-                    >
-                      <Text
-                        className={`font-medium ${selectedSmartGoalId === goal.id
-                          ? 'text-[#021A40]'
-                          : 'text-[#E6FAFF]'
-                          }`}
-                      >
-                        {goal.title}
-                      </Text>
-                    </Pressable>
-                  ))}
-                </View>
-              )}
-            </View>
+            <LinkedGoalSelector
+              goals={smartGoals}
+              isLoading={isLoadingSmartGoals}
+              selectedGoalId={selectedSmartGoalId}
+              onSelectGoal={setSelectedSmartGoalId}
+              disabled={createTaskMutation.isPending}
+            />
 
             <View className="gap-4">
               <PrimaryButton

--- a/app/smartGoals/[id].tsx
+++ b/app/smartGoals/[id].tsx
@@ -1,0 +1,204 @@
+import { type Task } from '@/api/tasks';
+import { PrimaryButton } from '@/components/buttons/';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { LoadingSpinner } from '@/components/loading';
+import LinearGradient from '@/components/ui/LinearGradient';
+import ScrollView from '@/components/util/ScrollView';
+import { useSmartGoal } from '@/hooks/useSmartGoals';
+import { Ionicons } from '@expo/vector-icons';
+import { useQueryClient } from '@tanstack/react-query';
+import { router, useLocalSearchParams } from 'expo-router';
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+export default function GoalDetailScreen() {
+  const queryClient = useQueryClient();
+  const { id } = useLocalSearchParams<{ id: string }>();
+  const goalId = parseInt(id || '0', 10);
+
+  return (
+    <ErrorBoundary
+      scope="goal-detail"
+      onReset={() => queryClient.invalidateQueries({ queryKey: ['smartGoal', goalId] })}
+    >
+      <GoalDetailContent goalId={goalId} />
+    </ErrorBoundary>
+  );
+}
+
+function GoalDetailContent({ goalId }: { goalId: number }) {
+  const { data: goal, isLoading, error } = useSmartGoal(goalId);
+
+  if (isLoading) {
+    return (
+      <LinearGradient>
+        <LoadingSpinner
+          size="large"
+          text="Loading goal..."
+          variant="fullscreen"
+          testID="goal-detail-loading"
+        />
+      </LinearGradient>
+    );
+  }
+
+  if (error || !goal) {
+    return (
+      <LinearGradient>
+        <View className="flex-1 justify-center items-center p-6">
+          <Text className="text-[#F1F5F9] text-lg text-center mb-4" testID="goal-detail-error-title">
+            Could not load goal
+          </Text>
+          <Text className="text-[#E6FAFF] text-center mb-6" testID="goal-detail-error-message">
+            {error instanceof Error ? error.message : 'Goal not found.'}
+          </Text>
+        </View>
+      </LinearGradient>
+    );
+  }
+
+  const openTasks = goal.tasks?.open ?? [];
+  const completedTasks = goal.tasks?.completed ?? [];
+  const hasAnyTasks = openTasks.length > 0 || completedTasks.length > 0;
+
+  return (
+    <LinearGradient>
+      <ScrollView className="flex-1 p-6" showsVerticalScrollIndicator={false}>
+        <View className="bg-[#2B42B6] rounded-2xl p-5 mb-6 shadow-lg border border-[#33CFFF]" style={cardShadow}>
+          <View className="flex-row justify-between items-start mb-4">
+            <Text
+              className="text-2xl font-semibold text-[#F1F5F9] flex-1 mr-4"
+              testID="goal-detail-title"
+            >
+              {goal.title}
+            </Text>
+            <View className={`px-3 py-1 rounded-full ${goal.completed ? 'bg-green-500' : 'bg-orange-500'}`}>
+              <Text className="text-sm font-semibold text-white" testID="goal-detail-status">
+                {goal.completed ? 'Complete' : 'In Progress'}
+              </Text>
+            </View>
+          </View>
+
+          {goal.target_date ? (
+            <View className="flex-row items-center mb-3">
+              <Ionicons name="calendar-outline" size={16} color="#E6FAFF" />
+              <Text className="text-[#E6FAFF] text-base ml-2" testID="goal-detail-target-date">
+                Target: {formatTargetDate(goal.target_date)}
+              </Text>
+            </View>
+          ) : null}
+
+          {goal.description ? (
+            <Text className="text-[#E6FAFF] text-base mt-2" testID="goal-detail-description">
+              {goal.description}
+            </Text>
+          ) : null}
+        </View>
+
+        <View className="bg-[#2B42B6] rounded-2xl p-5 mb-6 shadow-lg border border-[#33CFFF]" style={cardShadow}>
+          <Text className="text-lg font-semibold text-[#F1F5F9] mb-4">SMART Breakdown</Text>
+          <SmartField label="Specific" value={goal.specific} testID="goal-detail-specific" />
+          <SmartField label="Measurable" value={goal.measurable} testID="goal-detail-measurable" />
+          <SmartField label="Achievable" value={goal.achievable} testID="goal-detail-achievable" />
+          <SmartField label="Relevant" value={goal.relevant} testID="goal-detail-relevant" />
+          <SmartField label="Time-bound" value={goal.time_bound} testID="goal-detail-time-bound" last />
+        </View>
+
+        <View className="mb-6">
+          <View className="flex-row justify-between items-center mb-3">
+            <Text className="text-xl font-semibold text-[#F1F5F9]" testID="goal-detail-open-heading">
+              Open Tasks ({openTasks.length})
+            </Text>
+          </View>
+          {openTasks.length === 0 ? (
+            <EmptyTaskState
+              message={hasAnyTasks ? 'No open tasks for this goal.' : 'No tasks linked to this goal yet.'}
+              testID="goal-detail-open-empty"
+            />
+          ) : (
+            openTasks.map(task => <TaskRow key={task.id} task={task} />)
+          )}
+        </View>
+
+        {completedTasks.length > 0 ? (
+          <View className="mb-6">
+            <Text className="text-xl font-semibold text-[#F1F5F9] mb-3" testID="goal-detail-completed-heading">
+              Completed ({completedTasks.length})
+            </Text>
+            {completedTasks.map(task => <TaskRow key={task.id} task={task} muted />)}
+          </View>
+        ) : null}
+
+        <PrimaryButton
+          title="Add Task to This Goal"
+          icon="add"
+          onPress={() => router.push({ pathname: '/addTask', params: { smartGoalId: String(goalId) } })}
+          className="flex-row-reverse gap-2 mb-8"
+          testID="goal-detail-add-task-button"
+        />
+      </ScrollView>
+    </LinearGradient>
+  );
+}
+
+function SmartField({ label, value, testID, last }: { label: string; value?: string; testID: string; last?: boolean }) {
+  if (!value) return null;
+  return (
+    <View className={last ? '' : 'mb-3'}>
+      <Text className="text-[#708090] text-sm font-medium mb-1">{label}:</Text>
+      <Text className="text-[#E6FAFF] text-base" testID={testID}>{value}</Text>
+    </View>
+  );
+}
+
+function TaskRow({ task, muted }: { task: Task; muted?: boolean }) {
+  return (
+    <Pressable
+      className="flex-row justify-between items-center bg-[#2B42B6] rounded-xl p-4 mb-2 border border-[#33CFFF]"
+      style={cardShadow}
+      onPress={() => task.id && router.push(`/taskDetail/${task.id}`)}
+      testID={`goal-detail-task-${task.id}`}
+    >
+      <View className="flex-1 mr-3">
+        <Text
+          className={`text-base font-medium ${muted ? 'text-[#E6FAFF] opacity-70 line-through' : 'text-[#F1F5F9]'}`}
+          testID={`goal-detail-task-title-${task.id}`}
+        >
+          {task.title}
+        </Text>
+        {task.description ? (
+          <Text className="text-[#E6FAFF] text-sm mt-1 opacity-80" numberOfLines={2}>
+            {task.description}
+          </Text>
+        ) : null}
+      </View>
+      <Ionicons name="chevron-forward" size={18} color="#33CFFF" />
+    </Pressable>
+  );
+}
+
+function EmptyTaskState({ message, testID }: { message: string; testID: string }) {
+  return (
+    <View
+      className="bg-[#2B42B6] rounded-2xl p-6 items-center border border-[#33CFFF]"
+      style={cardShadow}
+    >
+      <Text className="text-[#708090] text-base text-center italic" testID={testID}>
+        {message}
+      </Text>
+    </View>
+  );
+}
+
+function formatTargetDate(iso: string): string {
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return d.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+const cardShadow = {
+  shadowColor: '#274B8E',
+  shadowOpacity: 0.1,
+  shadowRadius: 10,
+  shadowOffset: { width: 0, height: 3 },
+} as const;

--- a/app/smartGoals/index.tsx
+++ b/app/smartGoals/index.tsx
@@ -2,7 +2,6 @@ import AiOnboardingWizard from '@/components/AiOnboardingWizard';
 import { PrimaryButton } from '@/components/buttons/';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { LoadingSpinner } from '@/components/loading';
-import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
 import { useSmartGoals } from '@/hooks/useSmartGoals';
@@ -29,7 +28,6 @@ function SmartGoalsContent() {
   const { data: profile, isLoading: profileLoading } = useProfile();
   const { data: goals, isLoading: goalsLoading, error } = useSmartGoals();
   const [showWizard, setShowWizard] = useState(false);
-  const toast = useToast();
 
   const handleStartOnboarding = () => {
     setShowWizard(true);
@@ -160,7 +158,13 @@ function SmartGoalsContent() {
   };
 
   const renderGoal = (goal: any) => (
-    <View key={goal.id} className="bg-[#2B42B6] rounded-2xl p-5 mb-4 shadow-lg border border-[#33CFFF]" style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}>
+    <Pressable
+      key={goal.id}
+      className="bg-[#2B42B6] rounded-2xl p-5 mb-4 shadow-lg border border-[#33CFFF]"
+      style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}
+      onPress={() => router.push(`/smartGoals/${goal.id}`)}
+      testID={`smart-goals-goal-card-${goal.id}`}
+    >
       <View className="flex-row justify-between items-center mb-4">
         <Text className="text-xl font-semibold text-[#F1F5F9] flex-1 mr-4" testID={`smart-goals-goal-title-${goal.id}`}>{goal.title}</Text>
         <View className={`px-3 py-1 rounded-full ${goal.completed ? 'bg-green-500' : 'bg-orange-500'}`}>
@@ -190,21 +194,11 @@ function SmartGoalsContent() {
         <Text className="text-[#E6FAFF] text-base">{goal.relevant}</Text>
       </View>
 
-      <View className="mb-4">
+      <View>
         <Text className="text-[#708090] text-sm font-medium mb-1">Time-bound:</Text>
         <Text className="text-[#E6FAFF] text-base">{goal.time_bound}</Text>
       </View>
-
-      <Pressable
-        className="border-2 border-[#33CFFF] rounded-xl py-3 px-4 items-center"
-        onPress={() => {
-          // TODO: Navigate to edit goal screen
-          toast.info('Edit functionality coming soon!');
-        }}
-      >
-        <Text className="text-[#33CFFF] font-semibold text-base">Edit Goal</Text>
-      </Pressable>
-    </View>
+    </Pressable>
   );
 
   const renderTimeframeSection = (timeframe: string, goals: any[]) => (

--- a/app/taskDetail/[id].tsx
+++ b/app/taskDetail/[id].tsx
@@ -1,11 +1,12 @@
 import { UpdateTaskParams } from '@/api/tasks';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { LinkedGoalSelector } from '@/components/goals/LinkedGoalSelector';
 import { PRIORITY_OPTIONS, PriorityInput } from '@/components/inputs';
 import { LoadingSpinner } from '@/components/loading';
 import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
-import { useSmartGoal } from '@/hooks/useSmartGoals';
+import { useSmartGoal, useSmartGoals } from '@/hooks/useSmartGoals';
 import { useDeleteTask, useTask, useUpdateTask } from '@/hooks/useTasks';
 import { taskSchema } from '@/models';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -54,6 +55,7 @@ function TaskDetailContent() {
     isLoading: isLinkedGoalLoading,
     error: linkedGoalError,
   } = useSmartGoal(linkedGoalId ?? 0);
+  const { data: smartGoals = [], isLoading: isLoadingSmartGoals } = useSmartGoals();
 
   const { control, handleSubmit, formState: { errors, isValid }, reset } = useForm<EditTaskFormValues>({
     resolver: zodResolver(editTaskFormSchema),
@@ -68,6 +70,7 @@ function TaskDetailContent() {
 
   // editingMode: separate ref-like state via reset + a flag
   const [isEditing, setIsEditing] = React.useState(false);
+  const [selectedSmartGoalId, setSelectedSmartGoalId] = React.useState<number | null>(null);
 
   useEffect(() => {
     if (task) {
@@ -77,6 +80,7 @@ function TaskDetailContent() {
         action_category: task.action_category,
         priority: task.priority || 1,
       });
+      setSelectedSmartGoalId(task.smart_goal_id ?? null);
     }
   }, [task, reset]);
 
@@ -86,6 +90,7 @@ function TaskDetailContent() {
       description: values.description || undefined,
       action_category: values.action_category,
       priority: values.priority,
+      smart_goal_id: selectedSmartGoalId,
     };
 
     updateTaskMutation.mutate(
@@ -107,6 +112,7 @@ function TaskDetailContent() {
         action_category: task.action_category,
         priority: task.priority || 1,
       });
+      setSelectedSmartGoalId(task.smart_goal_id ?? null);
     }
     setIsEditing(false);
   };
@@ -384,6 +390,16 @@ function TaskDetailContent() {
                 </View>
               )}
             </View>
+
+            {isEditing ? (
+              <LinkedGoalSelector
+                goals={smartGoals}
+                isLoading={isLoadingSmartGoals}
+                selectedGoalId={selectedSmartGoalId}
+                onSelectGoal={setSelectedSmartGoalId}
+                disabled={updateTaskMutation.isPending}
+              />
+            ) : null}
 
             {linkedGoalId ? (
               <View className="mb-6" testID="task-detail-linked-goal-section">

--- a/app/taskDetail/[id].tsx
+++ b/app/taskDetail/[id].tsx
@@ -5,6 +5,7 @@ import { LoadingSpinner } from '@/components/loading';
 import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
+import { useSmartGoal } from '@/hooks/useSmartGoals';
 import { useDeleteTask, useTask, useUpdateTask } from '@/hooks/useTasks';
 import { taskSchema } from '@/models';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -47,6 +48,12 @@ function TaskDetailContent() {
   const toast = useToast();
 
   const { data: task, isLoading, error, refetch } = useTask(taskId);
+  const linkedGoalId = task?.smart_goal_id ?? null;
+  const {
+    data: linkedGoal,
+    isLoading: isLinkedGoalLoading,
+    error: linkedGoalError,
+  } = useSmartGoal(linkedGoalId ?? 0);
 
   const { control, handleSubmit, formState: { errors, isValid }, reset } = useForm<EditTaskFormValues>({
     resolver: zodResolver(editTaskFormSchema),
@@ -377,6 +384,35 @@ function TaskDetailContent() {
                 </View>
               )}
             </View>
+
+            {linkedGoalId ? (
+              <View className="mb-6" testID="task-detail-linked-goal-section">
+                <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Linked Goal</Text>
+                {isLinkedGoalLoading ? (
+                  <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
+                    <Text className="text-[#708090] text-base" testID="task-detail-linked-goal-loading">
+                      Loading goal...
+                    </Text>
+                  </View>
+                ) : linkedGoalError || !linkedGoal ? (
+                  <View className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]">
+                    <Text className="text-[#E6FAFF] text-base" testID="task-detail-linked-goal-error">
+                      Linked goal unavailable
+                    </Text>
+                  </View>
+                ) : (
+                  <Pressable
+                    className="px-4 py-3 rounded-xl bg-[#13203a] border border-[#708090]"
+                    onPress={() => router.push(`/smartGoals/${linkedGoal.id}`)}
+                    testID="task-detail-linked-goal-button"
+                  >
+                    <Text className="text-[#F1F5F9] text-base" testID="task-detail-linked-goal-title">
+                      {linkedGoal.title}
+                    </Text>
+                  </Pressable>
+                )}
+              </View>
+            ) : null}
 
             <View className="p-4 rounded-xl bg-[#2B42B6] border border-[#708090]" style={{ shadowColor: '#274B8E', shadowOpacity: 0.10, shadowRadius: 10, shadowOffset: { width: 0, height: 3 } }}>
               <Text className="text-[#E6FAFF] text-sm mb-2">Created: {new Date(task.created_at || '').toLocaleDateString()}</Text>

--- a/components/TaskItem.tsx
+++ b/components/TaskItem.tsx
@@ -9,6 +9,13 @@ interface TaskItemProps {
   onToggle: (taskId: number, completed: boolean) => void;
 }
 
+const GOAL_PILL_MAX_CHARS = 25;
+
+function truncateGoalTitle(title: string): string {
+  if (title.length <= GOAL_PILL_MAX_CHARS) return title;
+  return `${title.slice(0, GOAL_PILL_MAX_CHARS).trimEnd()}…`;
+}
+
 export default function TaskItem({ task, onToggle }: TaskItemProps) {
   const getCheckboxClassName = () => {
     const baseClasses = 'h-7 w-7 rounded-full border-2 mr-4';
@@ -39,6 +46,21 @@ export default function TaskItem({ task, onToggle }: TaskItemProps) {
 
       <View className="flex-1">
         <Text className={`font-bold ${task.completed ? 'text-[#708090]' : 'text-[#F1F5F9]'} text-[17px] mb-0.5 ${task.completed ? 'line-through' : ''} tracking-tight`} testID={`home-task-title-${task.id}`}>{task.title}</Text>
+        {task.smart_goal ? (
+          <Pressable
+            onPress={() => router.push(`/smartGoals/${task.smart_goal!.id}`)}
+            className="self-start flex-row items-center bg-[#13203a] border border-[#33CFFF] rounded-full px-2 py-0.5 mt-0.5 mb-0.5"
+            testID={`home-task-goal-pill-${task.id}`}
+          >
+            <FontAwesome name="flag" size={10} color="#33CFFF" />
+            <Text
+              className="text-[#E6FAFF] text-xs ml-1.5"
+              testID={`home-task-goal-pill-title-${task.id}`}
+            >
+              {truncateGoalTitle(task.smart_goal.title)}
+            </Text>
+          </Pressable>
+        ) : null}
         {task.description ? (
           <Text className={`${task.completed ? 'text-[#708090]' : 'text-[#E6FAFF]'} text-[15px] tracking-tight`} testID={`home-task-description-${task.id}`}>{task.description}</Text>
         ) : null}

--- a/components/goals/LinkedGoalSelector.tsx
+++ b/components/goals/LinkedGoalSelector.tsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+interface GoalOption {
+  id?: number;
+  title: string;
+}
+
+interface LinkedGoalSelectorProps {
+  goals: GoalOption[];
+  isLoading: boolean;
+  selectedGoalId: number | null;
+  onSelectGoal: (goalId: number | null) => void;
+  disabled?: boolean;
+}
+
+export function LinkedGoalSelector({
+  goals,
+  isLoading,
+  selectedGoalId,
+  onSelectGoal,
+  disabled = false,
+}: LinkedGoalSelectorProps) {
+  return (
+    <View className="mb-5" testID="add-task-goal-linking-section">
+      <Text className="text-[#E6FAFF] text-base mb-3 font-medium">Linked Goal (optional):</Text>
+      {isLoading ? (
+        <Text className="text-[#708090] text-sm" testID="add-task-goal-loading">
+          Loading goals...
+        </Text>
+      ) : (
+        <View className="gap-2">
+          {goals.map(goal => (
+            <Pressable
+              key={goal.id}
+              onPress={() => onSelectGoal(goal.id ?? null)}
+              className={`py-3 px-4 rounded-lg border ${selectedGoalId === goal.id
+                ? 'border-cyan-400 bg-cyan-400'
+                : 'border-[#708090] bg-[#13203a]'
+                }`}
+              disabled={disabled}
+              testID={`add-task-goal-option-${goal.id}`}
+            >
+              <Text
+                className={`font-medium ${selectedGoalId === goal.id
+                  ? 'text-[#021A40]'
+                  : 'text-[#E6FAFF]'
+                  }`}
+              >
+                {goal.title}
+              </Text>
+            </Pressable>
+          ))}
+
+          <Pressable
+            onPress={() => onSelectGoal(null)}
+            className={`py-3 px-4 rounded-lg border ${selectedGoalId === null
+              ? 'border-cyan-400 bg-cyan-400'
+              : 'border-[#708090] bg-[#13203a]'
+              }`}
+            disabled={disabled}
+            testID="add-task-goal-option-none"
+          >
+            <Text
+              className={`font-medium ${selectedGoalId === null
+                ? 'text-[#021A40]'
+                : 'text-[#E6FAFF]'
+                }`}
+            >
+              None
+            </Text>
+          </Pressable>
+        </View>
+      )}
+    </View>
+  );
+}

--- a/hooks/useSmartGoals.ts
+++ b/hooks/useSmartGoals.ts
@@ -21,6 +21,20 @@ export const useSmartGoals = () => {
   });
 };
 
+export const useSmartGoal = (id: number) => {
+  return useQuery({
+    queryKey: ['smartGoal', id],
+    queryFn: async () => {
+      const response = await smartGoalsApi.getSmartGoal(id);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data;
+    },
+    enabled: id > 0,
+  });
+};
+
 export const useCreateSmartGoal = () => {
   const queryClient = useQueryClient();
   


### PR DESCRIPTION
## Summary
Closes PC-B by making the goal↔task relationship visible and actionable across the client. The goals list now opens a dedicated **Goal Detail Screen** showing the goal's metadata, SMART fields, and its linked tasks split into open vs. completed sections. The task-creation and task-detail flows now support linking a task to a goal — both via a deep-link param (`addTask?smartGoalId=…`) and via an editable selector — backed by a shared `LinkedGoalSelector` component. Finally, every task row in the main list renders a small parent-goal pill that taps through to the goal detail screen, reinforcing the goal narrative everywhere a user interacts with their tasks.

Together these three pieces (PC-B1 + PC-B2 + PC-B3) turn the silently-existing `smart_goal_id` FK into a first-class part of the UX. The "personal coach" framing only works if users can see how their daily work ladders up to their goals — without this, the app reads as just another task list. The pill on every row is what carries the coaching reminder into the everyday flow; the detail screen is what gives that pill somewhere meaningful to land.

## Changes
- `app/smartGoals/[id].tsx`
  - New `GoalDetailScreen`: header card (title/status/target date/description), SMART breakdown, sectioned task list (open, completed), and an "Add Task to This Goal" CTA that deep-links to `addTask` with `smartGoalId`.
- `app/smartGoals/index.tsx`
  - Goal cards are now Pressables that push `/smartGoals/:id`; removed the placeholder "Edit Goal" affordance.
- `app/_layout.tsx`
  - Registered `smartGoals/[id]` Stack screen.
- `app/addTask/index.tsx`
  - Picks up `smartGoalId` route param and pre-selects it (drops `NaN` when the param is absent/invalid).
  - Replaces the inline goal-picker with the shared `LinkedGoalSelector`.
- `app/taskDetail/[id].tsx`
  - In edit mode, surfaces `LinkedGoalSelector` and persists `smart_goal_id` (including clearing).
- `components/goals/LinkedGoalSelector.tsx`
  - New reusable component for the goal-linking input, used by both addTask and taskDetail.
- `components/TaskItem.tsx`
  - Renders a flag-iconed pill (truncated at 25 chars) under the title when `task.smart_goal` is present; tapping it pushes `/smartGoals/:id`.
- `api/tasks.ts`
  - `Task` gains `smart_goal_id`, `due_at`, and a nested `smart_goal?: { id, title } | null`.
- `api/smartGoals.ts`
  - New `SmartGoalDetail` type; `getSmartGoal` returns the goal plus its sectioned tasks.
- `hooks/useSmartGoals.ts`
  - New `useSmartGoal(id)` query.
- `__tests__/screens/TaskDetailScreen.test.tsx`
  - Mocks `useSmartGoals` so the new selector wiring doesn't break detail-screen tests.

## Test Plan
- [x] `npm run typecheck` — clean.
- [x] `npx eslint` on every file touched in this branch — clean.
- [ ] Manual: open Goals → tap a goal → confirm SMART card, open/completed sections, and "Add Task to This Goal" deep-link.
- [ ] Manual: from Home, confirm goal pill appears on tasks with a `smart_goal`, truncates long titles, and navigates to the matching detail screen.
- [ ] Manual: create a task via `addTask` with `smartGoalId` param pre-filled, then edit it from TaskDetail to switch / clear the linked goal.

## Additional Notes
- Server counterpart ships alongside (`server` repo, same branch name): `GET /smart_goals/:id` returns sectioned tasks; task payloads now embed `smart_goal: { id, title }`; task params permit `smart_goal_id` and `due_at`. The client expects that server PR to land in the same release.
- The pill truncation is 25 chars (overriding the spec's "~16") to read better on iPhone-class widths; revisit if it wraps on smaller devices.
- The first commit on this branch (`WIP`) bundles the initial goal-detail scaffolding and PC-B2 wiring; subsequent commits split out the LinkedGoalSelector refactor, task-detail editing, and the PC-B3 pill cleanly.