### PR TITLE
feat: add journal feature

### DIFF
--- a/__tests__/screens/JournalEntryFormScreen.test.tsx
+++ b/__tests__/screens/JournalEntryFormScreen.test.tsx
@@ -1,0 +1,181 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import NewJournalEntryScreen from '../../app/journal/new';
+
+jest.mock('../../api/journals');
+
+jest.mock('@react-native-community/datetimepicker', () => ({
+  __esModule: true,
+  default: () => null,
+}));
+
+jest.mock('../../hooks/useJournal', () => ({
+  useJournal: jest.fn(),
+  useJournalEntries: jest.fn(),
+  useCreateJournalEntry: jest.fn(),
+  useJournalEntry: jest.fn(),
+  useUpdateJournalEntry: jest.fn(),
+  useDeleteJournalEntry: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn(), back: jest.fn(), replace: jest.fn() },
+  useLocalSearchParams: jest.fn(() => ({})),
+  useRouter: () => ({ push: jest.fn(), back: jest.fn(), replace: jest.fn() }),
+}));
+
+jest.mock('../../components/ToastManager', () => ({
+  useToast: () => ({
+    success: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    dismiss: jest.fn(),
+  }),
+}));
+
+const mockUseCreateJournalEntry = require('../../hooks/useJournal').useCreateJournalEntry;
+const mockUseLocalSearchParams = require('expo-router').useLocalSearchParams;
+const mockRouterReplace = require('expo-router').router.replace;
+
+function renderScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <NewJournalEntryScreen />
+    </QueryClientProvider>,
+  );
+}
+
+function mockMutation(overrides: Partial<{ mutate: jest.Mock; isPending: boolean }> = {}) {
+  const mutate = overrides.mutate ?? jest.fn();
+  mockUseCreateJournalEntry.mockReturnValue({
+    mutate,
+    isPending: overrides.isPending ?? false,
+    isError: false,
+    isSuccess: false,
+    error: null,
+    reset: jest.fn(),
+  });
+  return mutate;
+}
+
+describe('NewJournalEntryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocalSearchParams.mockReturnValue({});
+  });
+
+  it('renders the daily heading and prompts when entry_type=daily_journal', () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'daily_journal' });
+    mockMutation();
+
+    renderScreen();
+
+    expect(screen.getByTestId('journal-form-heading').props.children).toBe("Today's reflection");
+    const prompts = screen.getByTestId('journal-form-prompts');
+    expect(prompts).toBeTruthy();
+    expect(screen.getByText('• What progress did I make today?')).toBeTruthy();
+  });
+
+  it('renders the weekly heading and prompts when entry_type=weekly_reflection', () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'weekly_reflection' });
+    mockMutation();
+
+    renderScreen();
+
+    expect(screen.getByTestId('journal-form-heading').props.children).toBe('This week in review');
+    expect(screen.getByText('• What worked this week?')).toBeTruthy();
+  });
+
+  it('hides the prompt block when entry_type=general', () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'general' });
+    mockMutation();
+
+    renderScreen();
+
+    expect(screen.queryByTestId('journal-form-prompts')).toBeNull();
+  });
+
+  it('keeps the save button disabled until the body has content', () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'daily_journal' });
+    mockMutation();
+
+    renderScreen();
+
+    const saveButton = screen.getByTestId('journal-form-save-button');
+    expect(saveButton.props.accessibilityState?.disabled).toBe(true);
+  });
+
+  it('submits with trimmed body and entry_type, navigating to the journal tab on success', async () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'daily_journal' });
+    const mutate = mockMutation();
+
+    renderScreen();
+
+    fireEvent.changeText(screen.getByTestId('journal-form-title-input'), '  Today  ');
+    fireEvent.changeText(screen.getByTestId('journal-form-body-input'), '  Made real progress.  ');
+
+    const saveButton = screen.getByTestId('journal-form-save-button');
+    await waitFor(() => {
+      expect(saveButton.props.accessibilityState?.disabled).toBe(false);
+    });
+
+    fireEvent.press(saveButton);
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith(
+        {
+          title: 'Today',
+          body: 'Made real progress.',
+          entry_type: 'daily_journal',
+          occurred_on: expect.any(String),
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) }),
+      );
+    });
+
+    const onSuccess = mutate.mock.calls[0][1].onSuccess;
+    onSuccess();
+    expect(mockRouterReplace).toHaveBeenCalledWith('/(tabs)/journal');
+  });
+
+  it('sends title as an empty string when left blank', async () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'general' });
+    const mutate = mockMutation();
+
+    renderScreen();
+
+    fireEvent.changeText(screen.getByTestId('journal-form-body-input'), 'A free-form thought.');
+
+    const saveButton = screen.getByTestId('journal-form-save-button');
+    await waitFor(() => {
+      expect(saveButton.props.accessibilityState?.disabled).toBe(false);
+    });
+
+    fireEvent.press(saveButton);
+
+    await waitFor(() => {
+      expect(mutate).toHaveBeenCalledWith(
+        expect.objectContaining({ title: '', body: 'A free-form thought.', entry_type: 'general' }),
+        expect.anything(),
+      );
+    });
+  });
+
+  it('updates the prompts when the entry type toggle changes', () => {
+    mockUseLocalSearchParams.mockReturnValue({ entry_type: 'daily_journal' });
+    mockMutation();
+
+    renderScreen();
+    expect(screen.getByText('• What progress did I make today?')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('journal-form-entry-type-weekly_reflection'));
+    expect(screen.getByText('• What worked this week?')).toBeTruthy();
+
+    fireEvent.press(screen.getByTestId('journal-form-entry-type-general'));
+    expect(screen.queryByTestId('journal-form-prompts')).toBeNull();
+  });
+});

--- a/__tests__/screens/JournalHomeScreen.test.tsx
+++ b/__tests__/screens/JournalHomeScreen.test.tsx
@@ -1,0 +1,139 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen } from '@testing-library/react-native';
+import React from 'react';
+import JournalScreen from '../../app/(tabs)/journal';
+
+jest.mock('../../api/journals');
+
+jest.mock('../../hooks/useJournal', () => ({
+  useJournal: jest.fn(),
+  useJournalEntries: jest.fn(),
+  useCreateJournalEntry: jest.fn(),
+  useJournalEntry: jest.fn(),
+  useUpdateJournalEntry: jest.fn(),
+  useDeleteJournalEntry: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  router: { push: jest.fn(), back: jest.fn(), replace: jest.fn() },
+  useLocalSearchParams: () => ({}),
+  useRouter: () => ({ push: jest.fn(), back: jest.fn(), replace: jest.fn() }),
+}));
+
+const mockUseJournalEntries = require('../../hooks/useJournal').useJournalEntries;
+const mockRouterPush = require('expo-router').router.push;
+
+function renderScreen() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <JournalScreen />
+    </QueryClientProvider>,
+  );
+}
+
+describe('JournalScreen (Home)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the loading state while entries load', () => {
+    mockUseJournalEntries.mockReturnValue({
+      data: undefined,
+      isLoading: true,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderScreen();
+    expect(screen.getByTestId('journal-home-loading')).toBeTruthy();
+  });
+
+  it('renders an error state when the query fails', () => {
+    mockUseJournalEntries.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+      refetch: jest.fn(),
+    });
+
+    renderScreen();
+    expect(screen.getByTestId('journal-home-error-title')).toBeTruthy();
+    expect(screen.getByTestId('journal-home-error-message')).toBeTruthy();
+  });
+
+  it('renders the empty state when there are no entries', () => {
+    mockUseJournalEntries.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderScreen();
+    expect(screen.getByTestId('journal-home-title')).toBeTruthy();
+    expect(screen.getByTestId('journal-home-prompt')).toBeTruthy();
+    expect(screen.getByTestId('journal-home-empty')).toBeTruthy();
+  });
+
+  it('renders recent entries when the query has data', () => {
+    mockUseJournalEntries.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          journal_id: 1,
+          profile_id: 1,
+          title: 'Productive Monday',
+          body: 'Shipped the journal models today.',
+          entry_type: 'daily_journal',
+          occurred_on: '2026-05-22',
+        },
+        {
+          id: 2,
+          journal_id: 1,
+          profile_id: 1,
+          title: null,
+          body: 'Last week I focused too much on infra.',
+          entry_type: 'weekly_reflection',
+          occurred_on: '2026-05-17',
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderScreen();
+    expect(screen.getByTestId('journal-home-recent-list')).toBeTruthy();
+    expect(screen.getByTestId('journal-entry-row-1')).toBeTruthy();
+    expect(screen.getByTestId('journal-entry-row-2')).toBeTruthy();
+  });
+
+  it('routes to the daily entry form when the daily CTA is pressed', () => {
+    mockUseJournalEntries.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderScreen();
+    fireEvent.press(screen.getByTestId('journal-home-cta-daily'));
+    expect(mockRouterPush).toHaveBeenCalledWith('/journal/new?entry_type=daily_journal');
+  });
+
+  it('routes to the weekly entry form when the weekly CTA is pressed', () => {
+    mockUseJournalEntries.mockReturnValue({
+      data: [],
+      isLoading: false,
+      error: null,
+      refetch: jest.fn(),
+    });
+
+    renderScreen();
+    fireEvent.press(screen.getByTestId('journal-home-cta-weekly'));
+    expect(mockRouterPush).toHaveBeenCalledWith('/journal/new?entry_type=weekly_reflection');
+  });
+});

--- a/__tests__/screens/TabLayout.test.tsx
+++ b/__tests__/screens/TabLayout.test.tsx
@@ -73,7 +73,8 @@ describe('TabLayout', () => {
     const { getByText } = render(<TabLayout />);
 
     expect(getByText('Tasks')).toBeTruthy();
-    expect(getByText("Today's Focus")).toBeTruthy();
+    expect(getByText('Focus')).toBeTruthy();
+    expect(getByText('Journal')).toBeTruthy();
     expect(getByText('Menu')).toBeTruthy();
   });
 
@@ -168,6 +169,7 @@ describe('TabLayout', () => {
     expect(getByTestId('tabs-container')).toBeTruthy();
     expect(getByTestId('tab-index')).toBeTruthy();
     expect(getByTestId('tab-todaysFocus')).toBeTruthy();
+    expect(getByTestId('tab-journal')).toBeTruthy();
     expect(getByTestId('tab-menu')).toBeTruthy();
   });
 }); 

--- a/api/journals.ts
+++ b/api/journals.ts
@@ -1,0 +1,78 @@
+// API client for Rails server journal + journal_entries endpoints.
+// The server resolves "the default journal" itself, so clients never
+// supply profile_id or journal_id on writes.
+import { apiDelete, apiGet, apiPost, apiPut, type ApiResponse } from '../utils/apiRequest';
+import type { JournalEntryType } from '../models/journal';
+
+export interface Journal {
+  id: number;
+  title: string;
+  description?: string | null;
+  kind: 'default';
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface JournalEntry {
+  id: number;
+  journal_id: number;
+  profile_id: number;
+  title?: string | null;
+  body: string;
+  entry_type: JournalEntryType;
+  occurred_on: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface CreateJournalEntryParams {
+  title: string;
+  body: string;
+  entry_type: JournalEntryType;
+  occurred_on: string;
+}
+
+export interface UpdateJournalEntryParams {
+  title?: string | null;
+  body?: string;
+  entry_type?: JournalEntryType;
+  occurred_on?: string;
+}
+
+export interface JournalEntryFilters {
+  entry_type?: JournalEntryType;
+  occurred_on?: string;
+  start_date?: string;
+  end_date?: string;
+}
+
+export class JournalsAPI {
+  async getJournal(): Promise<ApiResponse<Journal>> {
+    return apiGet<Journal>('/journal');
+  }
+
+  async getEntries(filters: JournalEntryFilters = {}): Promise<ApiResponse<JournalEntry[]>> {
+    const params: Record<string, string> = {};
+    if (filters.entry_type) params.entry_type = filters.entry_type;
+    if (filters.occurred_on) params.occurred_on = filters.occurred_on;
+    if (filters.start_date) params.start_date = filters.start_date;
+    if (filters.end_date) params.end_date = filters.end_date;
+    return apiGet<JournalEntry[]>('/journal/journal_entries', params);
+  }
+
+  async getEntry(id: number): Promise<ApiResponse<JournalEntry>> {
+    return apiGet<JournalEntry>(`/journal/journal_entries/${id}`);
+  }
+
+  async createEntry(params: CreateJournalEntryParams): Promise<ApiResponse<JournalEntry>> {
+    return apiPost<JournalEntry>('/journal/journal_entries', { journal_entry: params });
+  }
+
+  async updateEntry(id: number, params: UpdateJournalEntryParams): Promise<ApiResponse<JournalEntry>> {
+    return apiPut<JournalEntry>(`/journal/journal_entries/${id}`, { journal_entry: params });
+  }
+
+  async deleteEntry(id: number): Promise<ApiResponse<void>> {
+    return apiDelete<void>(`/journal/journal_entries/${id}`);
+  }
+}

--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -55,8 +55,16 @@ export default function TabLayout() {
           name="todaysFocus"
           options={{
             headerShown: false,
-            title: "Today's Focus",
+            title: "Focus",
             tabBarIcon: ({ color }) => <Ionicons name="compass" size={28} color={color} />,
+          }}
+        />
+        <Tabs.Screen
+          name="journal"
+          options={{
+            title: 'Journal',
+            headerShown: false,
+            tabBarIcon: ({ color }) => <Ionicons name="book-outline" size={26} color={color} />,
           }}
         />
         <Tabs.Screen

--- a/app/(tabs)/journal.tsx
+++ b/app/(tabs)/journal.tsx
@@ -1,0 +1,150 @@
+import { JournalEntry } from '@/api/journals';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { LoadingSpinner } from '@/components/loading';
+import LinearGradient from '@/components/ui/LinearGradient';
+import ScrollView from '@/components/util/ScrollView';
+import { useJournalEntries } from '@/hooks/useJournal';
+import { JournalEntryType } from '@/models/journal';
+import { Ionicons } from '@expo/vector-icons';
+import { router } from 'expo-router';
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+
+const ENTRY_TYPE_LABELS: Record<JournalEntryType, string> = {
+  daily_journal: 'Daily journal',
+  weekly_reflection: 'Weekly reflection',
+  general: 'General',
+};
+
+const TODAY_PROMPT_BY_WEEKDAY: Record<number, { kind: JournalEntryType; copy: string }> = {
+  0: { kind: 'weekly_reflection', copy: "It's Sunday — take a moment to reflect on the week behind you." },
+  1: { kind: 'daily_journal', copy: 'What is one thing you want to focus on today?' },
+  2: { kind: 'daily_journal', copy: 'What progress did you make yesterday worth noticing?' },
+  3: { kind: 'daily_journal', copy: 'Halfway through the week — what is going well?' },
+  4: { kind: 'daily_journal', copy: 'What is the hardest thing on your plate right now?' },
+  5: { kind: 'daily_journal', copy: 'Friday check-in: what is one win from this week?' },
+  6: { kind: 'weekly_reflection', copy: 'Saturday is a great day to write a weekly reflection.' },
+};
+
+const startNewEntry = (entryType: JournalEntryType) => {
+  router.push(`/journal/new?entry_type=${entryType}` as any);
+};
+
+export default function JournalScreen() {
+  return (
+    <ErrorBoundary scope="journal-home">
+      <JournalHomeContent />
+    </ErrorBoundary>
+  );
+}
+
+function JournalHomeContent() {
+  const { data: entries = [], isLoading, error, refetch } = useJournalEntries();
+
+  if (isLoading) {
+    return (
+      <LinearGradient>
+        <LoadingSpinner size="large" text="Loading journal..." variant="fullscreen" testID="journal-home-loading" />
+      </LinearGradient>
+    );
+  }
+
+  if (error) {
+    return (
+      <LinearGradient>
+        <View className="flex-1 justify-center px-6">
+          <Text className="text-[#F1F5F9] text-lg text-center mb-2" testID="journal-home-error-title">
+            Could not load your journal
+          </Text>
+          <Text className="text-[#E6FAFF] text-center mb-6" testID="journal-home-error-message">
+            {error instanceof Error ? error.message : 'Unknown error'}
+          </Text>
+          <Pressable onPress={() => refetch()} className="bg-[#154FA6] px-6 py-3 rounded-lg self-center">
+            <Text className="text-[#021A40] font-semibold">Retry</Text>
+          </Pressable>
+        </View>
+      </LinearGradient>
+    );
+  }
+
+  const prompt = TODAY_PROMPT_BY_WEEKDAY[new Date().getDay()];
+  const recentEntries = entries.slice(0, 5);
+
+  return (
+    <LinearGradient>
+      <ScrollView contentContainerStyle={{ padding: 20, paddingBottom: 40 }}>
+        <Text
+          className="text-[28px] font-semibold mb-6 text-center text-[#F1F5F9] tracking-wide"
+          testID="journal-home-title"
+        >
+          Journal
+        </Text>
+
+        <View
+          className="rounded-2xl p-5 mb-6 bg-[#2B42B6] border border-[#274B8E]"
+          testID="journal-home-prompt"
+        >
+          <Text className="text-[#22d3ee] text-xs uppercase tracking-wider mb-2">Today&apos;s prompt</Text>
+          <Text className="text-[#F1F5F9] text-base leading-6">{prompt.copy}</Text>
+        </View>
+
+        <View className="gap-3 mb-8">
+          <Pressable
+            onPress={() => startNewEntry('daily_journal')}
+            className="rounded-2xl p-4 bg-[#154FA6] flex-row items-center"
+            testID="journal-home-cta-daily"
+          >
+            <Ionicons name="sunny-outline" size={22} color="#22d3ee" />
+            <Text className="text-[#F1F5F9] text-base font-semibold ml-3">Write daily journal</Text>
+          </Pressable>
+
+          <Pressable
+            onPress={() => startNewEntry('weekly_reflection')}
+            className="rounded-2xl p-4 bg-[#13203a] border border-[#274B8E] flex-row items-center"
+            testID="journal-home-cta-weekly"
+          >
+            <Ionicons name="calendar-outline" size={22} color="#22d3ee" />
+            <Text className="text-[#F1F5F9] text-base font-semibold ml-3">Weekly reflection</Text>
+          </Pressable>
+        </View>
+
+        <Text className="text-[#E6FAFF] text-base font-semibold mb-3">Recent entries</Text>
+
+        {recentEntries.length === 0 ? (
+          <View className="rounded-2xl p-6 bg-[#13203a] border border-[#274B8E]" testID="journal-home-empty">
+            <Text className="text-[#F1F5F9] text-base mb-1">No entries yet</Text>
+            <Text className="text-[#708090] text-sm">Tap a prompt above to write your first reflection.</Text>
+          </View>
+        ) : (
+          <View className="gap-3" testID="journal-home-recent-list">
+            {recentEntries.map((entry) => (
+              <JournalEntryRow key={entry.id} entry={entry} />
+            ))}
+          </View>
+        )}
+      </ScrollView>
+    </LinearGradient>
+  );
+}
+
+function JournalEntryRow({ entry }: { entry: JournalEntry }) {
+  const preview = entry.body.length > 120 ? `${entry.body.slice(0, 120).trim()}…` : entry.body;
+
+  return (
+    <View
+      className="rounded-2xl p-4 bg-[#2B42B6] border border-[#274B8E]"
+      testID={`journal-entry-row-${entry.id}`}
+    >
+      <View className="flex-row items-center justify-between mb-1">
+        <Text className="text-[#22d3ee] text-xs uppercase tracking-wider">
+          {ENTRY_TYPE_LABELS[entry.entry_type]}
+        </Text>
+        <Text className="text-[#708090] text-xs">{entry.occurred_on}</Text>
+      </View>
+      {entry.title ? (
+        <Text className="text-[#F1F5F9] text-base font-semibold mb-1">{entry.title}</Text>
+      ) : null}
+      <Text className="text-[#E6FAFF] text-sm leading-5">{preview}</Text>
+    </View>
+  );
+}

--- a/app/(tabs)/todaysFocus.tsx
+++ b/app/(tabs)/todaysFocus.tsx
@@ -22,6 +22,14 @@ export default function TodaysFocusScreen() {
   const createTaskMutation = useCreateTask();
   const toast = useToast();
 
+  const {
+    suggestions: aiSuggestions,
+    isLoading: aiLoading,
+    error: aiError,
+    generateSuggestions,
+    dismissSuggestion,
+  } = useAiSuggestedTasks();
+
   const [selectedTasks, setSelectedTasks] = useState<Task[]>([]);
   const [isFocusMode, setIsFocusMode] = useState(false);
   const [loadingSuggestions, setLoadingSuggestions] = useState<Set<string>>(new Set());
@@ -30,7 +38,7 @@ export default function TodaysFocusScreen() {
   if (!profile) {
     return (
       <LinearGradient>
-        <View className="flex-1 items-center justify-center px-5">
+        <View className="flex-1 justify-center items-center px-5">
           <LoadingSpinner
             size="medium"
             text="Loading your profile..."
@@ -41,14 +49,6 @@ export default function TodaysFocusScreen() {
       </LinearGradient>
     );
   }
-
-  const {
-    suggestions: aiSuggestions,
-    isLoading: aiLoading,
-    error: aiError,
-    generateSuggestions,
-    dismissSuggestion,
-  } = useAiSuggestedTasks();
 
   const sortSelectedTasks = (): Task[] => {
     const combinedTasks = [...selectedTasks, ...incompleteTasks];

--- a/app/journal/new.tsx
+++ b/app/journal/new.tsx
@@ -1,0 +1,329 @@
+import { CreateJournalEntryParams } from '@/api/journals';
+import { PrimaryButton, SecondaryButton } from '@/components/buttons';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { useToast } from '@/components/ToastManager';
+import LinearGradient from '@/components/ui/LinearGradient';
+import ScrollView from '@/components/util/ScrollView';
+import { useCreateJournalEntry } from '@/hooks/useJournal';
+import {
+  journalEntryFormSchema,
+  type JournalEntryFormValues,
+  type JournalEntryType,
+} from '@/models/journal';
+import { zodResolver } from '@hookform/resolvers/zod';
+import DateTimePicker, { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import { router, useLocalSearchParams } from 'expo-router';
+import React, { useCallback, useMemo, useState } from 'react';
+import { Controller, useForm } from 'react-hook-form';
+import { KeyboardAvoidingView, Platform, Pressable, Text, TextInput, View } from 'react-native';
+
+const fieldErrorClassName = 'text-red-400 text-xs mt-1';
+
+const ENTRY_TYPES: readonly { value: JournalEntryType; label: string }[] = [
+  { value: 'daily_journal', label: 'Daily' },
+  { value: 'weekly_reflection', label: 'Weekly' },
+  { value: 'general', label: 'General' },
+];
+
+const PROMPTS_BY_ENTRY_TYPE: Record<JournalEntryType, readonly string[]> = {
+  daily_journal: [
+    'What progress did I make today?',
+    'What felt hard?',
+    'What is one thing I can improve tomorrow?',
+  ],
+  weekly_reflection: [
+    'What worked this week?',
+    'What did not work?',
+    'What should I adjust next week?',
+  ],
+  general: [],
+};
+
+const HEADING_BY_ENTRY_TYPE: Record<JournalEntryType, string> = {
+  daily_journal: "Today's reflection",
+  weekly_reflection: 'This week in review',
+  general: 'New journal entry',
+};
+
+const isValidEntryType = (value: unknown): value is JournalEntryType =>
+  value === 'daily_journal' || value === 'weekly_reflection' || value === 'general';
+
+const formatOccurrenceDate = (value: Date) =>
+  value.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+
+const formatOccurrenceTime = (value: Date) =>
+  value.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' });
+
+export default function NewJournalEntryScreen() {
+  return (
+    <ErrorBoundary scope="journal-new-entry">
+      <NewJournalEntryContent />
+    </ErrorBoundary>
+  );
+}
+
+function NewJournalEntryContent() {
+  const toast = useToast();
+  const createMutation = useCreateJournalEntry();
+
+  const { entry_type: routeEntryType } = useLocalSearchParams<{ entry_type?: string }>();
+  const initialEntryType: JournalEntryType = isValidEntryType(routeEntryType)
+    ? routeEntryType
+    : 'daily_journal';
+
+  const {
+    control,
+    handleSubmit,
+    setValue,
+    watch,
+    formState: { errors, isValid },
+  } = useForm<JournalEntryFormValues>({
+    resolver: zodResolver(journalEntryFormSchema),
+    mode: 'onChange',
+    defaultValues: {
+      title: '',
+      body: '',
+      entry_type: initialEntryType,
+      occurred_on: new Date().toISOString(),
+    },
+  });
+
+  const selectedEntryType = watch('entry_type');
+  const occurredOnValue = watch('occurred_on');
+  const selectedOccurrence = useMemo(() => {
+    const occurredOnDate = new Date(occurredOnValue);
+    return Number.isNaN(occurredOnDate.getTime()) ? new Date() : occurredOnDate;
+  }, [occurredOnValue]);
+  const prompts = PROMPTS_BY_ENTRY_TYPE[selectedEntryType];
+  const [showDatePicker, setShowDatePicker] = useState(false);
+  const [showTimePicker, setShowTimePicker] = useState(false);
+
+  const updateOccurredOn = useCallback(
+    (nextDate: Date) => {
+      setValue('occurred_on', nextDate.toISOString(), { shouldValidate: true, shouldDirty: true });
+    },
+    [setValue]
+  );
+
+  const onDateChange = useCallback(
+    (event: DateTimePickerEvent, selectedDate?: Date) => {
+      if (Platform.OS === 'android') {
+        setShowDatePicker(false);
+      }
+      if (event.type !== 'set' || !selectedDate) {
+        return;
+      }
+
+      const nextDate = new Date(selectedOccurrence);
+      nextDate.setFullYear(selectedDate.getFullYear(), selectedDate.getMonth(), selectedDate.getDate());
+      updateOccurredOn(nextDate);
+    },
+    [selectedOccurrence, updateOccurredOn]
+  );
+
+  const onTimeChange = useCallback(
+    (event: DateTimePickerEvent, selectedTime?: Date) => {
+      if (Platform.OS === 'android') {
+        setShowTimePicker(false);
+      }
+      if (event.type !== 'set' || !selectedTime) {
+        return;
+      }
+
+      const nextDate = new Date(selectedOccurrence);
+      nextDate.setHours(selectedTime.getHours(), selectedTime.getMinutes(), 0, 0);
+      updateOccurredOn(nextDate);
+    },
+    [selectedOccurrence, updateOccurredOn]
+  );
+
+  const onSubmit = (values: JournalEntryFormValues) => {
+    const payload: CreateJournalEntryParams = {
+      title: values.title.trim(),
+      body: values.body.trim(),
+      entry_type: values.entry_type,
+      occurred_on: values.occurred_on,
+    };
+
+    createMutation.mutate(payload, {
+      onSuccess: () => router.replace('/(tabs)/journal' as any),
+      onError: (mutationError) => {
+        const message = mutationError instanceof Error ? mutationError.message : 'Could not save your entry';
+        toast.error(message);
+      },
+    });
+  };
+
+  return (
+    <LinearGradient>
+      <KeyboardAvoidingView behavior={Platform.OS === 'ios' ? 'padding' : 'height'} style={{ flex: 1 }}>
+        <ScrollView contentContainerStyle={{ flexGrow: 1, padding: 20, paddingBottom: 40 }}>
+          <View className="gap-4">
+            <Text
+              className="mt-6 mb-2 font-semibold text-center text-3xl text-[#F1F5F9]"
+              testID="journal-form-heading"
+            >
+              {HEADING_BY_ENTRY_TYPE[selectedEntryType]}
+            </Text>
+
+            <View className="mb-2">
+              <Text className="text-[#E6FAFF] text-sm mb-2 font-medium">Entry type</Text>
+              <Controller
+                control={control}
+                name="entry_type"
+                render={({ field: { value, onChange } }) => (
+                  <View className="flex-row gap-2">
+                    {ENTRY_TYPES.map(({ value: optionValue, label }) => {
+                      const selected = value === optionValue;
+                      return (
+                        <Pressable
+                          key={optionValue}
+                          onPress={() => onChange(optionValue)}
+                          className={`flex-1 py-2 px-3 rounded-lg border ${selected ? 'border-cyan-400 bg-cyan-400' : 'border-[#708090] bg-[#13203a]'
+                            }`}
+                          disabled={createMutation.isPending}
+                          testID={`journal-form-entry-type-${optionValue}`}
+                        >
+                          <Text
+                            className={`text-center font-medium ${selected ? 'text-[#021A40]' : 'text-[#E6FAFF]'
+                              }`}
+                          >
+                            {label}
+                          </Text>
+                        </Pressable>
+                      );
+                    })}
+                  </View>
+                )}
+              />
+            </View>
+
+            {prompts.length > 0 && (
+              <View
+                className="rounded-2xl p-4 bg-[#13203a] border border-[#274B8E]"
+                testID="journal-form-prompts"
+              >
+                <Text className="text-[#22d3ee] text-xs uppercase tracking-wider mb-2">Prompts</Text>
+                {prompts.map((prompt) => (
+                  <Text key={prompt} className="text-[#E6FAFF] text-sm leading-5 mb-1">
+                    • {prompt}
+                  </Text>
+                ))}
+              </View>
+            )}
+
+            <View>
+              <Controller
+                control={control}
+                name="title"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className="bg-[#2B42B6] rounded-2xl p-4 text-[#F1F5F9] text-base border border-[#274B8E]"
+                    placeholder="Title"
+                    placeholderTextColor="#708090"
+                    value={value ?? ''}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    editable={!createMutation.isPending}
+                    testID="journal-form-title-input"
+                  />
+                )}
+              />
+              {errors.title && <Text className={fieldErrorClassName}>{errors.title.message}</Text>}
+            </View>
+
+            <View>
+              <Text className="text-[#E6FAFF] text-sm mb-2 font-medium">Date and time</Text>
+              <View className="rounded-2xl p-4 bg-[#13203a] border border-[#274B8E] gap-3">
+                <Text className="text-[#E6FAFF] text-sm" testID="journal-form-occurred-on-value">
+                  {formatOccurrenceDate(selectedOccurrence)} at {formatOccurrenceTime(selectedOccurrence)}
+                </Text>
+                <View className="flex-row gap-2">
+                  <Pressable
+                    onPress={() => setShowDatePicker(true)}
+                    className="flex-1 py-2 px-3 rounded-lg border border-[#708090] bg-[#1b2a4a]"
+                    disabled={createMutation.isPending}
+                    testID="journal-form-date-picker-button"
+                  >
+                    <Text className="text-center font-medium text-[#E6FAFF]">Select date</Text>
+                  </Pressable>
+                  <Pressable
+                    onPress={() => setShowTimePicker(true)}
+                    className="flex-1 py-2 px-3 rounded-lg border border-[#708090] bg-[#1b2a4a]"
+                    disabled={createMutation.isPending}
+                    testID="journal-form-time-picker-button"
+                  >
+                    <Text className="text-center font-medium text-[#E6FAFF]">Select time</Text>
+                  </Pressable>
+                </View>
+              </View>
+              {errors.occurred_on && <Text className={fieldErrorClassName}>{errors.occurred_on.message}</Text>}
+            </View>
+
+            {showDatePicker && (
+              <DateTimePicker
+                testID="journal-form-date-picker"
+                value={selectedOccurrence}
+                mode="date"
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                onChange={onDateChange}
+              />
+            )}
+
+            {showTimePicker && (
+              <DateTimePicker
+                testID="journal-form-time-picker"
+                value={selectedOccurrence}
+                mode="time"
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                onChange={onTimeChange}
+              />
+            )}
+
+            <View>
+              <Controller
+                control={control}
+                name="body"
+                render={({ field: { value, onChange, onBlur } }) => (
+                  <TextInput
+                    className="bg-[#2B42B6] rounded-2xl p-4 text-[#F1F5F9] text-base border border-[#274B8E] min-h-[180px]"
+                    placeholder="Write your reflection…"
+                    placeholderTextColor="#708090"
+                    value={value}
+                    onChangeText={onChange}
+                    onBlur={onBlur}
+                    multiline
+                    textAlignVertical="top"
+                    editable={!createMutation.isPending}
+                    testID="journal-form-body-input"
+                  />
+                )}
+              />
+              {errors.body && (
+                <Text className={fieldErrorClassName} testID="journal-form-body-error">
+                  {errors.body.message}
+                </Text>
+              )}
+            </View>
+
+            <View className="gap-3 mt-4">
+              <PrimaryButton
+                title="Save entry"
+                onPress={handleSubmit(onSubmit)}
+                disabled={!isValid || createMutation.isPending}
+                isLoading={createMutation.isPending}
+                loadingText="Saving..."
+                testID="journal-form-save-button"
+              />
+              <SecondaryButton
+                title="Cancel"
+                onPress={() => router.back()}
+                testID="journal-form-cancel-button"
+              />
+            </View>
+          </View>
+        </ScrollView>
+      </KeyboardAvoidingView>
+    </LinearGradient>
+  );
+}

--- a/hooks/useJournal.ts
+++ b/hooks/useJournal.ts
@@ -1,0 +1,115 @@
+import {
+  CreateJournalEntryParams,
+  Journal,
+  JournalEntry,
+  JournalEntryFilters,
+  JournalsAPI,
+  UpdateJournalEntryParams,
+} from '@/api/journals';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+const journalsApi = new JournalsAPI();
+
+const entriesQueryKey = (filters?: JournalEntryFilters) =>
+  filters && Object.keys(filters).length > 0
+    ? (['journalEntries', filters] as const)
+    : (['journalEntries'] as const);
+
+export const useJournal = () => {
+  return useQuery<Journal>({
+    queryKey: ['journal'],
+    queryFn: async () => {
+      const response = await journalsApi.getJournal();
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      if (!response.data) {
+        throw new Error('Journal response was empty');
+      }
+      return response.data;
+    },
+    retry: 2,
+  });
+};
+
+export const useJournalEntries = (filters: JournalEntryFilters = {}) => {
+  return useQuery<JournalEntry[]>({
+    queryKey: entriesQueryKey(filters),
+    queryFn: async () => {
+      const response = await journalsApi.getEntries(filters);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data || [];
+    },
+    retry: 2,
+  });
+};
+
+export const useJournalEntry = (id: number) => {
+  return useQuery<JournalEntry | undefined>({
+    queryKey: ['journalEntry', id],
+    queryFn: async () => {
+      const response = await journalsApi.getEntry(id);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data;
+    },
+    enabled: id > 0,
+    retry: 2,
+  });
+};
+
+export const useCreateJournalEntry = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (params: CreateJournalEntryParams) => {
+      const response = await journalsApi.createEntry(params);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['journalEntries'] });
+      queryClient.invalidateQueries({ queryKey: ['journal'] });
+    },
+  });
+};
+
+export const useUpdateJournalEntry = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async ({ id, params }: { id: number; params: UpdateJournalEntryParams }) => {
+      const response = await journalsApi.updateEntry(id, params);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: (_data, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['journalEntries'] });
+      queryClient.invalidateQueries({ queryKey: ['journalEntry', variables.id] });
+    },
+  });
+};
+
+export const useDeleteJournalEntry = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: async (id: number) => {
+      const response = await journalsApi.deleteEntry(id);
+      if (response.error) {
+        throw new Error(response.error);
+      }
+      return response.data;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['journalEntries'] });
+    },
+  });
+};

--- a/models/index.ts
+++ b/models/index.ts
@@ -1,4 +1,5 @@
 export * from './auth';
+export * from './journal';
 export * from './profile';
 export * from './smartGoal';
 export * from './task';

--- a/models/journal.ts
+++ b/models/journal.ts
@@ -1,0 +1,43 @@
+import { z } from "zod";
+
+export const journalEntryTypeSchema = z.enum([
+  "daily_journal",
+  "weekly_reflection",
+  "general",
+]);
+
+export type JournalEntryType = z.infer<typeof journalEntryTypeSchema>;
+
+export const journalSchema = z.object({
+  id: z.number().int().positive(),
+  title: z.string(),
+  description: z.string().nullable().optional(),
+  kind: z.literal("default"),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export type JournalModel = z.infer<typeof journalSchema>;
+
+export const journalEntrySchema = z.object({
+  id: z.number().int().positive(),
+  journal_id: z.number().int().positive(),
+  profile_id: z.number().int().positive(),
+  title: z.string().trim().max(200),
+  body: z.string().trim().min(1, "Please write something"),
+  entry_type: journalEntryTypeSchema,
+  occurred_on: z.string(),
+  created_at: z.string().optional(),
+  updated_at: z.string().optional(),
+});
+
+export type JournalEntryModel = z.infer<typeof journalEntrySchema>;
+
+export const journalEntryFormSchema = journalEntrySchema.pick({
+  title: true,
+  body: true,
+  entry_type: true,
+  occurred_on: true,
+});
+
+export type JournalEntryFormValues = z.infer<typeof journalEntryFormSchema>;

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/vector-icons": "^15.0.3",
         "@hookform/resolvers": "^5.2.2",
         "@react-native-async-storage/async-storage": "^2.2.0",
+        "@react-native-community/datetimepicker": "8.4.4",
         "@react-navigation/bottom-tabs": "^7.3.10",
         "@react-navigation/elements": "^2.3.8",
         "@react-navigation/native": "^7.1.6",
@@ -4390,6 +4391,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.65 <1.0"
+      }
+    },
+    "node_modules/@react-native-community/datetimepicker": {
+      "version": "8.4.4",
+      "resolved": "https://registry.npmjs.org/@react-native-community/datetimepicker/-/datetimepicker-8.4.4.tgz",
+      "integrity": "sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "invariant": "^2.2.4"
+      },
+      "peerDependencies": {
+        "expo": ">=52.0.0",
+        "react": "*",
+        "react-native": "*",
+        "react-native-windows": "*"
+      },
+      "peerDependenciesMeta": {
+        "expo": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native/assets-registry": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@expo/vector-icons": "^15.0.3",
     "@hookform/resolvers": "^5.2.2",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.3.10",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",


### PR DESCRIPTION
## Summary
Adds a Journal feature to the client app — a new bottom-tab destination with a list/home view and a dedicated entry-creation screen. The feature ships with its own data layer (model, REST client, React Query hook) and screen-level tests.

To make room for a fourth tab, the existing "Today's Focus" tab label is shortened to "Focus". This branch also picks up a small rules-of-hooks fix in the Today's Focus screen — `useAiSuggestedTasks` was being called after a conditional early return when `profile` was null.

## Changes
- `package.json`, `package-lock.json`
  - Add `@react-native-community/datetimepicker@8.4.4` for date selection in the journal entry form.
- `models/journal.ts`, `models/index.ts`
  - New Journal model type; re-exported from the models barrel.
- `api/journals.ts`
  - REST client for journal entries.
- `hooks/useJournal.ts`
  - React Query hooks wrapping the journal API.
- `app/(tabs)/journal.tsx`
  - Journal home screen (list of entries) mounted as a tab.
- `app/journal/new.tsx`
  - Journal entry creation form, including date picker.
- `app/(tabs)/_layout.tsx`
  - Register the Journal tab. Rename "Today's Focus" → "Focus".
- `__tests__/screens/TabLayout.test.tsx`
  - Update to assert the new "Focus" / "Journal" tab labels and the `tab-journal` test ID.
- `__tests__/screens/JournalHomeScreen.test.tsx`, `__tests__/screens/JournalEntryFormScreen.test.tsx`
  - Coverage for the two new screens.
- `app/(tabs)/todaysFocus.tsx`
  - Hoist `useAiSuggestedTasks()` above the `if (!profile) return …` early return so the hook is always called.

## Test Plan
- [x] `npm test` — 41 suites, 394 tests passing.
- [x] Manual: open the app, switch to the Journal tab, create an entry with a date, confirm it appears in the home list.
- [x] Manual: confirm "Today's Focus" tab now reads "Focus" and still renders correctly.

## Additional Notes
- The server-side journal endpoints are assumed to already exist; this PR is client-only.
- No migration of existing tab state is needed — Expo Router will pick up the new tab on next reload.