### PR TITLE
feat: goal completion toggle and due-status badge on smart goal cards

### DIFF
--- a/__tests__/screens/GoalDetailScreen.test.tsx
+++ b/__tests__/screens/GoalDetailScreen.test.tsx
@@ -1,0 +1,284 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react-native';
+import React from 'react';
+import { Alert } from 'react-native';
+import GoalDetailScreen from '../../app/smartGoals/[id]';
+
+jest.mock('../../hooks/useSmartGoals', () => ({
+  useSmartGoal: jest.fn(),
+  useUpdateSmartGoal: jest.fn(),
+}));
+
+jest.mock('expo-router', () => ({
+  useLocalSearchParams: () => ({ id: '42' }),
+  router: { push: jest.fn(), back: jest.fn() },
+}));
+
+jest.mock('../../components/ToastManager', () => ({
+  useToast: () => ({ success: jest.fn(), error: jest.fn() }),
+}));
+
+jest.spyOn(Alert, 'alert').mockImplementation(() => {});
+
+const mockUseSmartGoal = require('../../hooks/useSmartGoals').useSmartGoal;
+const mockUseUpdateSmartGoal = require('../../hooks/useSmartGoals').useUpdateSmartGoal;
+
+const mockMutate = jest.fn();
+const defaultMutation = { mutate: mockMutate, isPending: false };
+
+const baseGoal = {
+  id: 42,
+  title: 'Learn TypeScript',
+  description: 'Deep dive into TS',
+  timeframe: '3_months',
+  specific: 'Complete TS course',
+  measurable: 'Pass final assessment',
+  achievable: 'Study 1h daily',
+  relevant: 'Career growth',
+  time_bound: 'Within 3 months',
+  completed: false,
+  target_date: '2026-06-01',
+  profile_id: 1,
+  created_at: '2026-01-01T00:00:00Z',
+  updated_at: '2026-01-01T00:00:00Z',
+  tasks: { open: [], completed: [] },
+};
+
+function renderScreen(queryClient: QueryClient) {
+  return render(
+    <QueryClientProvider client={queryClient}>
+      <GoalDetailScreen />
+    </QueryClientProvider>
+  );
+}
+
+describe('GoalDetailScreen', () => {
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    queryClient = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    jest.clearAllMocks();
+    mockUseUpdateSmartGoal.mockReturnValue(defaultMutation);
+  });
+
+  it('renders loading state', () => {
+    mockUseSmartGoal.mockReturnValue({ data: undefined, isLoading: true, error: null });
+
+    renderScreen(queryClient);
+
+    expect(screen.getByTestId('goal-detail-loading')).toBeTruthy();
+  });
+
+  it('renders error state', () => {
+    mockUseSmartGoal.mockReturnValue({
+      data: undefined,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+
+    renderScreen(queryClient);
+
+    expect(screen.getByTestId('goal-detail-error-title')).toBeTruthy();
+    expect(screen.getByTestId('goal-detail-error-message')).toBeTruthy();
+  });
+
+  it('renders goal title, SMART breakdown, and status pill', () => {
+    mockUseSmartGoal.mockReturnValue({ data: baseGoal, isLoading: false, error: null });
+
+    renderScreen(queryClient);
+
+    expect(screen.getByTestId('goal-detail-title')).toBeTruthy();
+    expect(screen.getByText('Learn TypeScript')).toBeTruthy();
+    expect(screen.getByTestId('goal-detail-status')).toBeTruthy();
+    expect(screen.getByText('In Progress')).toBeTruthy();
+    expect(screen.getByTestId('goal-detail-specific')).toBeTruthy();
+  });
+
+  it('renders "Mark as Complete" button for in-progress goal', () => {
+    mockUseSmartGoal.mockReturnValue({ data: baseGoal, isLoading: false, error: null });
+
+    renderScreen(queryClient);
+
+    expect(screen.getByTestId('goal-detail-complete-button-text')).toBeTruthy();
+    expect(screen.getByText('Mark as Complete')).toBeTruthy();
+  });
+
+  it('renders "Reopen Goal" button for completed goal', () => {
+    const completedGoal = { ...baseGoal, completed: true };
+    mockUseSmartGoal.mockReturnValue({ data: completedGoal, isLoading: false, error: null });
+
+    renderScreen(queryClient);
+
+    expect(screen.getByText('Reopen Goal')).toBeTruthy();
+    expect(screen.getByText('Complete')).toBeTruthy();
+  });
+
+  it('shows Alert.alert confirmation when "Mark as Complete" is pressed', () => {
+    mockUseSmartGoal.mockReturnValue({ data: baseGoal, isLoading: false, error: null });
+
+    renderScreen(queryClient);
+
+    fireEvent.press(screen.getByTestId('goal-detail-complete-button'));
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Mark Goal Complete',
+      'Mark this goal as complete?',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel' }),
+        expect.objectContaining({ text: 'Complete' }),
+      ])
+    );
+  });
+
+  it('shows Alert.alert confirmation when "Reopen Goal" is pressed', () => {
+    const completedGoal = { ...baseGoal, completed: true };
+    mockUseSmartGoal.mockReturnValue({ data: completedGoal, isLoading: false, error: null });
+
+    renderScreen(queryClient);
+
+    fireEvent.press(screen.getByTestId('goal-detail-complete-button'));
+
+    expect(Alert.alert).toHaveBeenCalledWith(
+      'Reopen Goal',
+      'Set this goal back to In Progress?',
+      expect.arrayContaining([
+        expect.objectContaining({ text: 'Cancel' }),
+        expect.objectContaining({ text: 'Reopen' }),
+      ])
+    );
+  });
+
+  it('calls mutation with completed: true when confirmation is confirmed', () => {
+    mockUseSmartGoal.mockReturnValue({ data: baseGoal, isLoading: false, error: null });
+    (Alert.alert as jest.Mock).mockImplementationOnce((_title, _msg, buttons) => {
+      const confirmButton = buttons.find((b: any) => b.text === 'Complete');
+      confirmButton?.onPress?.();
+    });
+
+    renderScreen(queryClient);
+
+    fireEvent.press(screen.getByTestId('goal-detail-complete-button'));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { id: 42, data: { completed: true } },
+      expect.any(Object)
+    );
+  });
+
+  it('calls mutation with completed: false when reopen is confirmed', () => {
+    const completedGoal = { ...baseGoal, completed: true };
+    mockUseSmartGoal.mockReturnValue({ data: completedGoal, isLoading: false, error: null });
+    (Alert.alert as jest.Mock).mockImplementationOnce((_title, _msg, buttons) => {
+      const confirmButton = buttons.find((b: any) => b.text === 'Reopen');
+      confirmButton?.onPress?.();
+    });
+
+    renderScreen(queryClient);
+
+    fireEvent.press(screen.getByTestId('goal-detail-complete-button'));
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      { id: 42, data: { completed: false } },
+      expect.any(Object)
+    );
+  });
+
+  describe('due badge on detail screen', () => {
+    beforeEach(() => {
+      jest.useFakeTimers({ now: new Date('2026-05-25T12:00:00') });
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('shows "Due today" badge when target_date is today', () => {
+      const goal = { ...baseGoal, target_date: '2026-05-25', completed: false };
+      mockUseSmartGoal.mockReturnValue({ data: goal, isLoading: false, error: null });
+
+      renderScreen(queryClient);
+
+      expect(screen.getByTestId('goal-detail-due-badge')).toBeTruthy();
+      expect(screen.getByText('Due today')).toBeTruthy();
+    });
+
+    it('shows "Due yesterday" badge when target_date was yesterday and goal is incomplete', () => {
+      const goal = { ...baseGoal, target_date: '2026-05-24', completed: false };
+      mockUseSmartGoal.mockReturnValue({ data: goal, isLoading: false, error: null });
+
+      renderScreen(queryClient);
+
+      expect(screen.getByText('Due yesterday')).toBeTruthy();
+    });
+
+    it('shows "5 days until due" badge for target 5 days away', () => {
+      const goal = { ...baseGoal, target_date: '2026-05-30', completed: false };
+      mockUseSmartGoal.mockReturnValue({ data: goal, isLoading: false, error: null });
+
+      renderScreen(queryClient);
+
+      expect(screen.getByText('5 days until due')).toBeTruthy();
+    });
+
+    it('shows "3 days past due" badge for target 3 days ago and incomplete', () => {
+      const goal = { ...baseGoal, target_date: '2026-05-22', completed: false };
+      mockUseSmartGoal.mockReturnValue({ data: goal, isLoading: false, error: null });
+
+      renderScreen(queryClient);
+
+      expect(screen.getByText('3 days past due')).toBeTruthy();
+    });
+
+    it('hides due badge when goal is completed and target date is past', () => {
+      const goal = { ...baseGoal, target_date: '2026-05-20', completed: true };
+      mockUseSmartGoal.mockReturnValue({ data: goal, isLoading: false, error: null });
+
+      renderScreen(queryClient);
+
+      expect(screen.queryByTestId('goal-detail-due-badge')).toBeNull();
+    });
+
+    it('shows neutral date badge when target is more than 30 days away', () => {
+      const goal = { ...baseGoal, target_date: '2026-07-01', completed: false };
+      mockUseSmartGoal.mockReturnValue({ data: goal, isLoading: false, error: null });
+
+      renderScreen(queryClient);
+
+      expect(screen.getByTestId('goal-detail-due-badge')).toBeTruthy();
+    });
+  });
+
+  it('navigates to add task screen when "Add Task" button is pressed', () => {
+    mockUseSmartGoal.mockReturnValue({ data: baseGoal, isLoading: false, error: null });
+    const mockPush = require('expo-router').router.push;
+
+    renderScreen(queryClient);
+
+    fireEvent.press(screen.getByTestId('goal-detail-add-task-button'));
+
+    expect(mockPush).toHaveBeenCalledWith(
+      expect.objectContaining({ pathname: '/addTask' })
+    );
+  });
+
+  it('renders tasks list when goal has tasks', () => {
+    const goalWithTasks = {
+      ...baseGoal,
+      tasks: {
+        open: [{ id: 1, title: 'Task One', description: null }],
+        completed: [{ id: 2, title: 'Task Two', description: null }],
+      },
+    };
+    mockUseSmartGoal.mockReturnValue({ data: goalWithTasks, isLoading: false, error: null });
+
+    renderScreen(queryClient);
+
+    expect(screen.getByTestId('goal-detail-task-1')).toBeTruthy();
+    expect(screen.getByTestId('goal-detail-completed-heading')).toBeTruthy();
+  });
+});

--- a/__tests__/screens/SmartGoalsScreen.test.tsx
+++ b/__tests__/screens/SmartGoalsScreen.test.tsx
@@ -337,6 +337,71 @@ describe('SmartGoalsScreen', () => {
     expect(mockPush).toHaveBeenCalledWith('/addGoal');
   });
 
+  it('shows due badge on goal cards based on target_date', () => {
+    const mockProfile = { id: 1, onboarding_status: 'complete' };
+
+    // Pin the system clock so date-diff is deterministic
+    jest.useFakeTimers({ now: new Date('2026-05-25T12:00:00') });
+
+    const mockGoals = [
+      {
+        id: 10,
+        title: 'Past Due Goal',
+        timeframe: '1_month',
+        specific: 'S', measurable: 'M', achievable: 'A', relevant: 'R', time_bound: 'T',
+        completed: false,
+        target_date: '2026-05-23',
+        profile_id: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 11,
+        title: 'Due Soon Goal',
+        timeframe: '1_month',
+        specific: 'S', measurable: 'M', achievable: 'A', relevant: 'R', time_bound: 'T',
+        completed: false,
+        target_date: '2026-05-30',
+        profile_id: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+      {
+        id: 12,
+        title: 'Completed Past-Due Goal',
+        timeframe: '1_month',
+        specific: 'S', measurable: 'M', achievable: 'A', relevant: 'R', time_bound: 'T',
+        completed: true,
+        target_date: '2026-05-20',
+        profile_id: 1,
+        created_at: '2026-01-01T00:00:00Z',
+        updated_at: '2026-01-01T00:00:00Z',
+      },
+    ];
+
+    mockUseProfile.mockReturnValue({ data: mockProfile, isLoading: false, error: null });
+    mockUseSmartGoals.mockReturnValue({ data: mockGoals, isLoading: false, error: null });
+
+    render(
+      <QueryClientProvider client={queryClient}>
+        <SmartGoalsScreen />
+      </QueryClientProvider>
+    );
+
+    // Goal 10: 2 days past due, not completed → danger badge
+    expect(screen.getByTestId('smart-goals-due-badge-10')).toBeTruthy();
+    expect(screen.getByText('2 days past due')).toBeTruthy();
+
+    // Goal 11: 5 days until due, not completed → warning badge
+    expect(screen.getByTestId('smart-goals-due-badge-11')).toBeTruthy();
+    expect(screen.getByText('5 days until due')).toBeTruthy();
+
+    // Goal 12: completed + past date → badge hidden (no element for this goal)
+    expect(screen.queryByTestId('smart-goals-due-badge-12')).toBeNull();
+
+    jest.useRealTimers();
+  });
+
   it('handles onboarding wizard completion', () => {
     const mockProfile = {
       id: 1,

--- a/__tests__/utils/smartGoalFormatters.test.ts
+++ b/__tests__/utils/smartGoalFormatters.test.ts
@@ -2,6 +2,7 @@ import {
   TIMEFRAME_MAPPER,
   TIMEFRAME_OPTIONS,
   formatTimeframeForAiResponse,
+  getGoalDueStatus,
   getServerTimeframe,
   validateGoalData,
   type TimeframeOption
@@ -120,6 +121,107 @@ describe('smartGoalFormatters', () => {
       expect(() => {
         getServerTimeframe('invalid');
       }).toThrow('Invalid timeframe: invalid');
+    });
+  });
+
+  describe('getGoalDueStatus', () => {
+    const TODAY = new Date('2026-05-25T12:00:00');
+
+    const dateAtOffset = (days: number): string => {
+      const d = new Date('2026-05-25');
+      d.setDate(d.getDate() + days);
+      return d.toISOString().split('T')[0];
+    };
+
+    it('returns "none" for missing target date', () => {
+      const result = getGoalDueStatus(undefined, false, TODAY);
+      expect(result.kind).toBe('none');
+    });
+
+    it('returns "none" for invalid target date', () => {
+      const result = getGoalDueStatus('not-a-date', false, TODAY);
+      expect(result.kind).toBe('none');
+    });
+
+    it('returns formatted date for dayDiff > 30 (31 days away)', () => {
+      const result = getGoalDueStatus(dateAtOffset(31), false, TODAY);
+      expect(result.kind).toBe('date');
+      expect(result.variant).toBe('neutral');
+      expect(result.label).toMatch(/\d{4}/);
+    });
+
+    it('returns "30 days until due" for dayDiff === 30', () => {
+      const result = getGoalDueStatus(dateAtOffset(30), false, TODAY);
+      expect(result.kind).toBe('due_soon');
+      expect(result.variant).toBe('warning');
+      expect(result.label).toBe('30 days until due');
+    });
+
+    it('returns "2 days until due" for dayDiff === 2', () => {
+      const result = getGoalDueStatus(dateAtOffset(2), false, TODAY);
+      expect(result.kind).toBe('due_soon');
+      expect(result.label).toBe('2 days until due');
+    });
+
+    it('returns "1 day until due" (singular) for dayDiff === 1', () => {
+      const result = getGoalDueStatus(dateAtOffset(1), false, TODAY);
+      expect(result.kind).toBe('due_soon');
+      expect(result.label).toBe('1 day until due');
+    });
+
+    it('returns "Due today" for dayDiff === 0', () => {
+      const result = getGoalDueStatus(dateAtOffset(0), false, TODAY);
+      expect(result.kind).toBe('due_today');
+      expect(result.variant).toBe('warning');
+      expect(result.label).toBe('Due today');
+    });
+
+    it('returns "Due today" even when completed (today is not past)', () => {
+      const result = getGoalDueStatus(dateAtOffset(0), true, TODAY);
+      expect(result.kind).toBe('due_today');
+      expect(result.label).toBe('Due today');
+    });
+
+    it('returns "Due yesterday" for dayDiff === -1 and not completed', () => {
+      const result = getGoalDueStatus(dateAtOffset(-1), false, TODAY);
+      expect(result.kind).toBe('due_yesterday');
+      expect(result.variant).toBe('danger');
+      expect(result.label).toBe('Due yesterday');
+    });
+
+    it('returns "none" for dayDiff === -1 and completed', () => {
+      const result = getGoalDueStatus(dateAtOffset(-1), true, TODAY);
+      expect(result.kind).toBe('none');
+    });
+
+    it('returns "2 days past due" for dayDiff === -2 and not completed', () => {
+      const result = getGoalDueStatus(dateAtOffset(-2), false, TODAY);
+      expect(result.kind).toBe('past_due');
+      expect(result.variant).toBe('danger');
+      expect(result.label).toBe('2 days past due');
+    });
+
+    it('returns "10 days past due" for dayDiff === -10 and not completed', () => {
+      const result = getGoalDueStatus(dateAtOffset(-10), false, TODAY);
+      expect(result.kind).toBe('past_due');
+      expect(result.label).toBe('10 days past due');
+    });
+
+    it('returns "1 day past due" (singular) for dayDiff === -1... wait this is tested above', () => {
+      // dayDiff === -1 shows "Due yesterday" (not "1 day past due")
+      const result = getGoalDueStatus(dateAtOffset(-1), false, TODAY);
+      expect(result.label).toBe('Due yesterday');
+    });
+
+    it('returns "none" for dayDiff === -10 and completed (hide badge for completed past-due)', () => {
+      const result = getGoalDueStatus(dateAtOffset(-10), true, TODAY);
+      expect(result.kind).toBe('none');
+    });
+
+    it('returns formatted date for dayDiff > 30 even when completed', () => {
+      const result = getGoalDueStatus(dateAtOffset(60), true, TODAY);
+      expect(result.kind).toBe('date');
+      expect(result.variant).toBe('neutral');
     });
   });
 

--- a/app/smartGoals/[id].tsx
+++ b/app/smartGoals/[id].tsx
@@ -1,15 +1,17 @@
 import { type Task } from '@/api/tasks';
 import { PrimaryButton } from '@/components/buttons/';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { GoalDueBadge } from '@/components/goals/GoalDueBadge';
 import { LoadingSpinner } from '@/components/loading';
+import { useToast } from '@/components/ToastManager';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
-import { useSmartGoal } from '@/hooks/useSmartGoals';
+import { useSmartGoal, useUpdateSmartGoal } from '@/hooks/useSmartGoals';
 import { Ionicons } from '@expo/vector-icons';
 import { useQueryClient } from '@tanstack/react-query';
 import { router, useLocalSearchParams } from 'expo-router';
 import React from 'react';
-import { Pressable, Text, View } from 'react-native';
+import { ActivityIndicator, Alert, Pressable, Text, View } from 'react-native';
 
 export default function GoalDetailScreen() {
   const queryClient = useQueryClient();
@@ -28,6 +30,8 @@ export default function GoalDetailScreen() {
 
 function GoalDetailContent({ goalId }: { goalId: number }) {
   const { data: goal, isLoading, error } = useSmartGoal(goalId);
+  const updateMutation = useUpdateSmartGoal();
+  const toast = useToast();
 
   if (isLoading) {
     return (
@@ -61,6 +65,49 @@ function GoalDetailContent({ goalId }: { goalId: number }) {
   const completedTasks = goal.tasks?.completed ?? [];
   const hasAnyTasks = openTasks.length > 0 || completedTasks.length > 0;
 
+  const performToggle = (completed: boolean) => {
+    updateMutation.mutate(
+      { id: goalId, data: { completed } },
+      {
+        onSuccess: () => {
+          toast.success(completed ? 'Goal marked complete!' : 'Goal reopened');
+        },
+        onError: () => {
+          toast.error('Failed to update goal. Please try again.');
+        },
+      }
+    );
+  };
+
+  const handleToggleCompletion = () => {
+    if (goal.completed) {
+      Alert.alert(
+        'Reopen Goal',
+        'Set this goal back to In Progress?',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Reopen', onPress: () => performToggle(false) },
+        ]
+      );
+    } else {
+      Alert.alert(
+        'Mark Goal Complete',
+        'Mark this goal as complete?',
+        [
+          { text: 'Cancel', style: 'cancel' },
+          { text: 'Complete', onPress: () => performToggle(true) },
+        ]
+      );
+    }
+  };
+
+  const completionButtonLabel = () => {
+    if (updateMutation.isPending) {
+      return goal.completed ? 'Reopening...' : 'Completing...';
+    }
+    return goal.completed ? 'Reopen Goal' : 'Mark as Complete';
+  };
+
   return (
     <LinearGradient>
       <ScrollView className="flex-1 p-6" showsVerticalScrollIndicator={false}>
@@ -72,10 +119,17 @@ function GoalDetailContent({ goalId }: { goalId: number }) {
             >
               {goal.title}
             </Text>
-            <View className={`px-3 py-1 rounded-full ${goal.completed ? 'bg-green-500' : 'bg-orange-500'}`}>
-              <Text className="text-sm font-semibold text-white" testID="goal-detail-status">
-                {goal.completed ? 'Complete' : 'In Progress'}
-              </Text>
+            <View className="items-end gap-1">
+              <View className={`px-3 py-1 rounded-full ${goal.completed ? 'bg-green-500' : 'bg-orange-500'}`}>
+                <Text className="text-sm font-semibold text-white" testID="goal-detail-status">
+                  {goal.completed ? 'Complete' : 'In Progress'}
+                </Text>
+              </View>
+              <GoalDueBadge
+                targetDate={goal.target_date}
+                completed={goal.completed}
+                testID="goal-detail-due-badge"
+              />
             </View>
           </View>
 
@@ -103,6 +157,34 @@ function GoalDetailContent({ goalId }: { goalId: number }) {
           <SmartField label="Relevant" value={goal.relevant} testID="goal-detail-relevant" />
           <SmartField label="Time-bound" value={goal.time_bound} testID="goal-detail-time-bound" last />
         </View>
+
+        <Pressable
+          className={`flex-row justify-center items-center p-4 rounded-2xl mb-6 ${goal.completed ? 'border border-orange-500' : 'bg-green-600'}`}
+          onPress={handleToggleCompletion}
+          disabled={updateMutation.isPending}
+          testID="goal-detail-complete-button"
+        >
+          {updateMutation.isPending ? (
+            <ActivityIndicator
+              size="small"
+              color={goal.completed ? '#f97316' : 'white'}
+              style={{ marginRight: 8 }}
+            />
+          ) : (
+            <Ionicons
+              name={goal.completed ? 'refresh-outline' : 'checkmark-circle-outline'}
+              size={20}
+              color={goal.completed ? '#f97316' : 'white'}
+              style={{ marginRight: 8 }}
+            />
+          )}
+          <Text
+            className={`font-semibold text-base ${goal.completed ? 'text-orange-500' : 'text-white'}`}
+            testID="goal-detail-complete-button-text"
+          >
+            {completionButtonLabel()}
+          </Text>
+        </Pressable>
 
         <View className="mb-6">
           <View className="flex-row justify-between items-center mb-3">

--- a/app/smartGoals/index.tsx
+++ b/app/smartGoals/index.tsx
@@ -1,6 +1,7 @@
 import AiOnboardingWizard from '@/components/AiOnboardingWizard';
 import { PrimaryButton } from '@/components/buttons/';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { GoalDueBadge } from '@/components/goals/GoalDueBadge';
 import { LoadingSpinner } from '@/components/loading';
 import LinearGradient from '@/components/ui/LinearGradient';
 import ScrollView from '@/components/util/ScrollView';
@@ -167,10 +168,17 @@ function SmartGoalsContent() {
     >
       <View className="flex-row justify-between items-center mb-4">
         <Text className="text-xl font-semibold text-[#F1F5F9] flex-1 mr-4" testID={`smart-goals-goal-title-${goal.id}`}>{goal.title}</Text>
-        <View className={`px-3 py-1 rounded-full ${goal.completed ? 'bg-green-500' : 'bg-orange-500'}`}>
-          <Text className="text-sm font-semibold text-white">
-            {goal.completed ? 'Complete' : 'In Progress'}
-          </Text>
+        <View className="items-end gap-1">
+          <View className={`px-3 py-1 rounded-full ${goal.completed ? 'bg-green-500' : 'bg-orange-500'}`}>
+            <Text className="text-sm font-semibold text-white">
+              {goal.completed ? 'Complete' : 'In Progress'}
+            </Text>
+          </View>
+          <GoalDueBadge
+            targetDate={goal.target_date}
+            completed={goal.completed}
+            testID={`smart-goals-due-badge-${goal.id}`}
+          />
         </View>
       </View>
 

--- a/components/goals/GoalDueBadge.tsx
+++ b/components/goals/GoalDueBadge.tsx
@@ -1,0 +1,31 @@
+import { getGoalDueStatus, type GoalDueVariant } from '@/utils/smartGoalFormatters';
+import React from 'react';
+import { Text, View } from 'react-native';
+
+const VARIANT_STYLES: Record<GoalDueVariant, { container: string; text: string }> = {
+  neutral: { container: 'bg-[#274B8E]', text: 'text-[#33CFFF]' },
+  warning: { container: 'bg-orange-800', text: 'text-orange-300' },
+  danger: { container: 'bg-red-900', text: 'text-red-400' },
+};
+
+interface GoalDueBadgeProps {
+  targetDate: string | undefined;
+  completed: boolean;
+  testID?: string;
+}
+
+export function GoalDueBadge({ targetDate, completed, testID }: GoalDueBadgeProps) {
+  const status = getGoalDueStatus(targetDate, completed);
+
+  if (status.kind === 'none') return null;
+
+  const styles = VARIANT_STYLES[status.variant];
+
+  return (
+    <View className={`px-2 py-1 rounded-full ${styles.container}`}>
+      <Text className={`text-xs font-medium ${styles.text}`} testID={testID}>
+        {status.label}
+      </Text>
+    </View>
+  );
+}

--- a/hooks/useSmartGoals.ts
+++ b/hooks/useSmartGoals.ts
@@ -80,8 +80,9 @@ export const useUpdateSmartGoal = () => {
       }
       return response.data;
     },
-    onSuccess: () => {
+    onSuccess: (_, { id }) => {
       queryClient.invalidateQueries({ queryKey: ['smartGoals'] });
+      queryClient.invalidateQueries({ queryKey: ['smartGoal', id] });
     },
   });
 };

--- a/utils/smartGoalFormatters.ts
+++ b/utils/smartGoalFormatters.ts
@@ -101,3 +101,98 @@ export const validateGoalData = (
 
   return { isValid: true };
 };
+
+// ---------------------------------------------------------------------------
+// Due-status badge logic
+// ---------------------------------------------------------------------------
+
+const MS_PER_DAY = 86_400_000;
+
+export type GoalDueVariant = 'neutral' | 'warning' | 'danger';
+export type GoalDueKind = 'date' | 'due_soon' | 'due_today' | 'due_yesterday' | 'past_due' | 'none';
+
+export interface GoalDueStatus {
+  label: string;
+  variant: GoalDueVariant;
+  kind: GoalDueKind;
+}
+
+const NONE_STATUS: GoalDueStatus = { label: '', variant: 'neutral', kind: 'none' };
+
+function startOfDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
+ * Parses a YYYY-MM-DD date string as a local-time date, avoiding the
+ * UTC-midnight shift that `new Date('YYYY-MM-DD')` produces in most timezones.
+ */
+function parseLocalDate(dateStr: string): Date | null {
+  const parts = dateStr.split('T')[0].split('-').map(Number);
+  if (parts.length !== 3 || parts.some(Number.isNaN)) return null;
+  const [year, month, day] = parts;
+  const d = new Date(year, month - 1, day);
+  if (Number.isNaN(d.getTime())) return null;
+  return d;
+}
+
+function formatDisplayDate(date: Date): string {
+  return date.toLocaleDateString(undefined, { year: 'numeric', month: 'short', day: 'numeric' });
+}
+
+/**
+ * Returns the due-status label and styling variant for a goal card/badge.
+ *
+ * Day-diff rules (targetStart - todayStart in whole days):
+ *   > 30            → formatted date (neutral)
+ *   1 – 30          → "X day(s) until due" (warning)
+ *   0               → "Due today" (warning)
+ *   -1, !completed  → "Due yesterday" (danger)
+ *   ≤ -2, !completed → "X day(s) past due" (danger)
+ *   past + completed → none (hide badge)
+ *   missing/invalid  → none
+ */
+export function getGoalDueStatus(
+  targetDate: string | undefined,
+  completed: boolean,
+  now: Date = new Date()
+): GoalDueStatus {
+  if (!targetDate) return NONE_STATUS;
+
+  const target = parseLocalDate(targetDate);
+  if (!target) return NONE_STATUS;
+
+  const todayStart = startOfDay(now);
+  const targetStart = startOfDay(target);
+  const dayDiff = Math.floor((targetStart.getTime() - todayStart.getTime()) / MS_PER_DAY);
+
+  if (dayDiff > 30) {
+    return { label: formatDisplayDate(target), variant: 'neutral', kind: 'date' };
+  }
+
+  if (dayDiff >= 1) {
+    const days = dayDiff;
+    return {
+      label: `${days} ${days === 1 ? 'day' : 'days'} until due`,
+      variant: 'warning',
+      kind: 'due_soon',
+    };
+  }
+
+  if (dayDiff === 0) {
+    return { label: 'Due today', variant: 'warning', kind: 'due_today' };
+  }
+
+  if (completed) return NONE_STATUS;
+
+  if (dayDiff === -1) {
+    return { label: 'Due yesterday', variant: 'danger', kind: 'due_yesterday' };
+  }
+
+  const absDays = Math.abs(dayDiff);
+  return {
+    label: `${absDays} ${absDays === 1 ? 'day' : 'days'} past due`,
+    variant: 'danger',
+    kind: 'past_due',
+  };
+}


### PR DESCRIPTION
## Summary
This PR now includes two related slices of work: (1) smart goal completion + due-status badges and (2) task scheduling datetime improvements for add/edit flows.

The smart goal slice adds completion toggles with confirmation dialogs and due-status badges on list/detail screens. The task scheduling slice adds explicit due/reminder editing UI in task screens, standardizes reminder payloads to datetime strings, and improves datetime picker dismissal behavior on iOS/Android.

### Why
The goal completion/badge work improves execution visibility for SMART goals. The task scheduling updates align client payloads and UX with backend datetime handling for `due_at` and `reminder_at`.

## Changes
- `utils/smartGoalFormatters.ts`
  - Added `GoalDueStatus` types and `getGoalDueStatus` with local-date parsing
- `components/goals/GoalDueBadge.tsx`
  - New shared badge component for due status states
- `hooks/useSmartGoals.ts`
  - Fixed `useUpdateSmartGoal` invalidation for both list and detail caches
- `app/smartGoals/[id].tsx`
  - Added complete/reopen button, confirmation flow, toast feedback, and due badge on detail
- `app/smartGoals/index.tsx`
  - Added due badge on goal cards
- `app/addTask/index.tsx`
  - Added due/reminder scheduling controls with `DateTimeField`
  - Defaults due date from linked goal `target_date`
  - Sends `due_at`/`reminder_at` as datetime strings (ISO)
- `app/taskDetail/[id].tsx`
  - Added due/reminder display in read mode
  - Added due/reminder editing controls in edit mode
  - Sends `due_at`/`reminder_at` as datetime strings (ISO)
- `components/inputs/DateTimeField.tsx`
  - Improved picker open/close behavior and added explicit iOS dismiss actions
- `components/inputs/TimeField.tsx`
  - Added reusable time-only input component and export
- `api/tasks.ts`
  - Updated task payload typings for nullable `reminder_at`
- `__tests__/utils/smartGoalFormatters.test.ts`
  - Added due-status formatter cases across boundaries
- `__tests__/screens/SmartGoalsScreen.test.tsx`
  - Added badge rendering/absence coverage on list cards
- `__tests__/screens/GoalDetailScreen.test.tsx`
  - Added goal detail completion and badge behavior coverage
- `__tests__/screens/AddTaskScreen.test.tsx`
  - Added due/reminder flow and payload coverage for add task
- `__tests__/screens/TaskDetailScreen.test.tsx`
  - Added due/reminder render/edit coverage for task detail

## Test Plan
- [x] `npx jest --testPathPattern="smartGoalFormatters|SmartGoalsScreen|GoalDetailScreen"`
- [x] `npx jest --no-coverage`
- [x] `npm test -- --runTestsByPath __tests__/screens/AddTaskScreen.test.tsx __tests__/screens/TaskDetailScreen.test.tsx`
- [ ] Manual: complete/reopen a goal and verify confirmation, status updates, and badge behavior
- [ ] Manual: create/edit a task with due/reminder values and verify persisted datetime behavior

## Additional Notes
- `DateTimeField` now closes predictably across platforms; iOS includes explicit dismiss controls.
- Reminder payloads now use datetime strings to align with backend datetime modeling.

Made with [Cursor](https://cursor.com)